### PR TITLE
Release v1.1.0: add guardFunctions option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,3 +134,5 @@ The following rules apply to all source code under `src/`:
   - OK: `({ a, b, c }) => {}`
 - **Braces required on `if` statements** — Never omit braces, even for single-line bodies. Arrow function expression bodies are exempt.
 - **Return type inference** — Omit explicit return type annotations where TypeScript can infer them. Exception: recursive functions must annotate their return type.
+- **`no-shadow`** — Avoid variable/parameter names that shadow an identifier from an outer scope. When destructuring inside a nested function, rename the bindings if they clash with outer names (e.g. `{ left: lhs, right: rhs }`).
+- **No single-character variable names** — Use descriptive names even for short-lived callback parameters. Prefer `prop` over `p`, `ifNode` over `n`, `switchCase` over `c`.

--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ input.addEventListener('keydown', (e) => {
 
 `keypress` is **prohibited entirely** as it is deprecated.
 
-> **Safari note:** In Safari, `compositionend` fires before `keydown`, so `e.isComposing` is `false` when Enter confirms IME. The `e.keyCode === 229` check covers this gap. To require only `e.isComposing` (if Safari support is not needed), set `{ checkKeyCodeForSafari: false }` in the rule options.
+**Safari note:** In Safari, `compositionend` fires before `keydown`, so `e.isComposing` is `false` when Enter confirms IME. The `e.keyCode === 229` check covers this gap. To require only `e.isComposing` (if Safari support is not needed), set `{ checkKeyCodeForSafari: false }` in the rule options.
 
-> **Custom guard functions:** If you extract the `isComposing` check into a shared helper, use the `guardFunctions` option to register the function name so the rule recognises it as an IME guard:
->
-> ```js
-> const guardIsComposing = (e) => e.isComposing || e.keyCode === 229;
->
-> // eslint.config.js
-> rules: { 'ime-safe-form/require-ime-safe-submit': ['warn', { guardFunctions: ['guardIsComposing'] }] }
-> ```
+**Custom guard functions:** If you extract the `isComposing` check into a shared helper, use the `guardFunctions` option to register the function name so the rule recognises it as an IME guard:
+
+```js
+const guardIsComposing = (e) => e.isComposing || e.keyCode === 229;
+
+// eslint.config.js
+rules: { 'ime-safe-form/require-ime-safe-submit': ['warn', { guardFunctions: ['guardIsComposing'] }] }
+```
 
 ## Installation
 
@@ -78,11 +78,11 @@ export default [
 ];
 ```
 
-> **Note:** The `recommended` config sets the rule severity to `"warn"`. To treat violations as errors, configure the rule manually:
->
-> ```js
-> rules: { 'ime-safe-form/require-ime-safe-submit': 'error' }
-> ```
+**Note:** The `recommended` config sets the rule severity to `"warn"`. To treat violations as errors, configure the rule manually:
+
+```js
+rules: { 'ime-safe-form/require-ime-safe-submit': 'error' }
+```
 
 ### Manual configuration
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ input.addEventListener('keydown', (e) => {
 
 > **Safari note:** In Safari, `compositionend` fires before `keydown`, so `e.isComposing` is `false` when Enter confirms IME. The `e.keyCode === 229` check covers this gap. To require only `e.isComposing` (if Safari support is not needed), set `{ checkKeyCodeForSafari: false }` in the rule options.
 
+> **Custom guard functions:** If you extract the `isComposing` check into a shared helper, use the `guardFunctions` option to register the function name so the rule recognises it as an IME guard:
+>
+> ```js
+> const guardIsComposing = (e) => e.isComposing || e.keyCode === 229;
+>
+> // eslint.config.js
+> rules: { 'ime-safe-form/require-ime-safe-submit': ['warn', { guardFunctions: ['guardIsComposing'] }] }
+> ```
+
 ## Installation
 
 ```sh

--- a/docs/rules/require-ime-safe-submit.md
+++ b/docs/rules/require-ime-safe-submit.md
@@ -129,6 +129,7 @@ input.addEventListener('keydown', (e) => {
 |---|---|
 | `e.isComposing \|\| e.keyCode === 229` guard in `keydown`/`keyup` | Default — covers both standard browsers and Safari |
 | `e.isComposing` guard alone (with `checkKeyCodeForSafari: false`) | Author opted out of Safari check |
+| Guard function call in `IfStatement` (with `guardFunctions` option) | Function is declared as an equivalent IME guard |
 | Enter check inside a nested function | Out of scope for the keydown handler |
 | Named function reference (`addEventListener('keydown', fn)`) | Cannot statically analyze external function bodies |
 
@@ -147,6 +148,40 @@ input.addEventListener('keydown', (e) => {
   ```
 
 ## Options
+
+### `guardFunctions` (default: `[]`)
+
+If your codebase extracts the `isComposing` check into a shared helper, list those function names here. The rule will treat a call to any of these functions inside an `if` statement as an equivalent IME guard, and will not flag the handler.
+
+```js
+// eslint.config.js
+export default [
+  {
+    ...imeSafeForm.configs.recommended,
+    rules: {
+      'ime-safe-form/require-ime-safe-submit': ['warn', {
+        guardFunctions: ['guardIsComposing'],
+      }],
+    },
+  },
+];
+```
+
+```js
+// ✅ Recognised as an IME guard — no error
+const guardIsComposing = (e) => e.isComposing || e.keyCode === 229;
+
+input.addEventListener('keydown', (e) => {
+  if (guardIsComposing(e)) return;
+  if (e.key === 'Enter') submit();
+});
+```
+
+Negated calls (`if (!guardIsComposing(e))`) and calls inside compound conditions (`&&`, `||`) are also recognised.
+
+> **Note:** The rule cannot inspect the body of the guard function. It trusts that any function listed in `guardFunctions` correctly handles IME state, including the Safari `keyCode === 229` case. The `requireKeyCode229` check is skipped for these handlers.
+
+> **Note:** `guardFunctions` has no effect on `keypress` handlers — `keypress` is prohibited regardless of any guard.
 
 ### `checkKeyCodeForSafari` (default: `true`)
 

--- a/docs/rules/require-ime-safe-submit.md
+++ b/docs/rules/require-ime-safe-submit.md
@@ -179,9 +179,11 @@ input.addEventListener('keydown', (e) => {
 
 Negated calls (`if (!guardIsComposing(e))`) and calls inside compound conditions (`&&`, `||`) are also recognised.
 
-> **Note:** The rule cannot inspect the body of the guard function. It trusts that any function listed in `guardFunctions` correctly handles IME state, including the Safari `keyCode === 229` case. The `requireKeyCode229` check is skipped for these handlers.
+> [!NOTE]
+> The rule cannot inspect the body of the guard function. It trusts that any function listed in `guardFunctions` correctly handles IME state, including the Safari `keyCode === 229` case. The `requireKeyCode229` check is skipped for these handlers.
 
-> **Note:** `guardFunctions` has no effect on `keypress` handlers — `keypress` is prohibited regardless of any guard.
+> [!NOTE]
+> `guardFunctions` has no effect on `keypress` handlers — `keypress` is prohibited regardless of any guard.
 
 ### `checkKeyCodeForSafari` (default: `true`)
 
@@ -215,7 +217,8 @@ input.addEventListener('keydown', (e) => {
 });
 ```
 
-> **Note:** `e.keyCode` is deprecated but remains the only reliable way to detect IME composition in Safari's event order. Set `checkKeyCodeForSafari: false` if Safari support is not a concern — `e.isComposing` alone will then be accepted.
+> [!NOTE]
+> `e.keyCode` is deprecated but remains the only reliable way to detect IME composition in Safari's event order. Set `checkKeyCodeForSafari: false` if Safari support is not a concern — `e.isComposing` alone will then be accepted.
 
 ## When Not to Use
 

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -58,18 +58,18 @@ const isEnterKeyBinaryExpression = (node: Node) => {
     return false;
   }
 
-  const isEnterString = ({ left, right }: { left: Node; right: Node }) =>
-    ENTER_STRING_PROPS.some((p) => isMemberWithProp({ node: left, propName: p })) &&
-    isLiteral({ node: right, value: 'Enter' });
-  const isEnterCode = ({ left, right }: { left: Node; right: Node }) =>
-    LEGACY_CODE_PROPS.some((p) => isMemberWithProp({ node: left, propName: p })) &&
-    isLiteral({ node: right, value: 13 });
+  const isEnterString = ({ leftOperand, rightOperand }: { leftOperand: Node; rightOperand: Node }) =>
+    ENTER_STRING_PROPS.some((prop) => isMemberWithProp({ node: leftOperand, propName: prop })) &&
+    isLiteral({ node: rightOperand, value: 'Enter' });
+  const isEnterCode = ({ leftOperand, rightOperand }: { leftOperand: Node; rightOperand: Node }) =>
+    LEGACY_CODE_PROPS.some((prop) => isMemberWithProp({ node: leftOperand, propName: prop })) &&
+    isLiteral({ node: rightOperand, value: 13 });
 
   return (
-    isEnterString({ left, right }) ||
-    isEnterString({ left: right, right: left }) ||
-    isEnterCode({ left, right }) ||
-    isEnterCode({ left: right, right: left })
+    isEnterString({ leftOperand: left, rightOperand: right }) ||
+    isEnterString({ leftOperand: right, rightOperand: left }) ||
+    isEnterCode({ leftOperand: left, rightOperand: right }) ||
+    isEnterCode({ leftOperand: right, rightOperand: left })
   );
 };
 
@@ -87,12 +87,15 @@ const isEnterKeySwitchStatement = (node: Node) => {
   const { discriminant, cases } = node;
 
   const hasCase = (value: string | number) =>
-    cases.some((c) => c.test !== null && c.test !== undefined && isLiteral({ node: c.test, value }));
+    cases.some(
+      (switchCase) =>
+        switchCase.test !== null && switchCase.test !== undefined && isLiteral({ node: switchCase.test, value }),
+    );
 
-  if (ENTER_STRING_PROPS.some((p) => isMemberWithProp({ node: discriminant, propName: p }))) {
+  if (ENTER_STRING_PROPS.some((prop) => isMemberWithProp({ node: discriminant, propName: prop }))) {
     return hasCase('Enter');
   }
-  if (LEGACY_CODE_PROPS.some((p) => isMemberWithProp({ node: discriminant, propName: p }))) {
+  if (LEGACY_CODE_PROPS.some((prop) => isMemberWithProp({ node: discriminant, propName: prop }))) {
     return hasCase(13);
   }
 
@@ -173,11 +176,11 @@ const isKeyCode229BinaryExpression = (node: Node) => {
  */
 export const hasKeyCode229Check = (node: Node | null | undefined) =>
   walkAst({
-    predicate: (n) =>
-      n.type === 'IfStatement' &&
+    predicate: (candidateNode) =>
+      candidateNode.type === 'IfStatement' &&
       walkAst({
         predicate: (child) => isKeyCode229BinaryExpression(child),
-        node: n.test,
+        node: candidateNode.test,
       }),
     node,
   });
@@ -190,11 +193,11 @@ export const hasKeyCode229Check = (node: Node | null | undefined) =>
  */
 export const hasIsComposingCheck = (node: Node | null | undefined) =>
   walkAst({
-    predicate: (n) =>
-      n.type === 'IfStatement' &&
+    predicate: (candidateNode) =>
+      candidateNode.type === 'IfStatement' &&
       walkAst({
         predicate: (child) => isMemberWithProp({ node: child, propName: 'isComposing' }),
-        node: n.test,
+        node: candidateNode.test,
       }),
     node,
   });

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -201,3 +201,35 @@ export const hasIsComposingCheck = (node: Node | null | undefined) =>
       }),
     node,
   });
+
+/**
+ * Returns true if the handler body contains an IfStatement whose condition
+ * calls one of the specified guard function names. This allows users to
+ * extract the isComposing guard into a helper and declare it via the
+ * `guardFunctions` option.
+ *
+ *   const guardIsComposing = (e) => e.isComposing || e.keyCode === 229;
+ *   input.addEventListener('keydown', (e) => {
+ *     if (guardIsComposing(e)) return;  ← recognised as a guard
+ *     if (e.key === 'Enter') submit();
+ *   });
+ */
+export const hasGuardFunctionCall = ({
+  node,
+  guardFunctions,
+}: {
+  node: Node | null | undefined;
+  guardFunctions: string[];
+}) =>
+  walkAst({
+    predicate: (candidateNode) =>
+      candidateNode.type === 'IfStatement' &&
+      walkAst({
+        predicate: (child) =>
+          child.type === 'CallExpression' &&
+          child.callee.type === 'Identifier' &&
+          guardFunctions.includes(child.callee.name),
+        node: candidateNode.test,
+      }),
+    node,
+  });

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -4,6 +4,7 @@ import {
   containsEnterKeyCheck,
   DEPRECATED_JSX_KEY_EVENTS,
   DEPRECATED_KEY_EVENTS,
+  hasGuardFunctionCall,
   hasIsComposingCheck,
   hasKeyCode229Check,
   JSX_KEY_EVENTS,
@@ -13,13 +14,11 @@ import type { JSXAttribute } from './helpers';
 
 const messages = {
   requireImeSafeSubmit:
-    "Enter key detected in '{{eventName}}' without an IME composition guard. " +
-    "Add 'if (e.isComposing) return;' before the check, or handle submission via the form's 'submit' event.",
+    "Enter key detected in '{{eventName}}' without an IME composition guard. Add 'if (e.isComposing) return;' before the check, or handle submission via the form's 'submit' event.",
   keypressProhibited:
     "'keypress' is deprecated. Use 'keydown' with an e.isComposing guard instead, or handle submission via the form's 'submit' event.",
   requireKeyCode229:
-    'In Safari, compositionend fires before keydown, so e.isComposing is false when Enter confirms IME. ' +
-    "Add '|| e.keyCode === 229' to the guard: 'if (e.isComposing || e.keyCode === 229) return;'.",
+    "In Safari, compositionend fires before keydown, so e.isComposing is false when Enter confirms IME. Add '|| e.keyCode === 229' to the guard: 'if (e.isComposing || e.keyCode === 229) return;'.",
 } as const;
 
 const rule: Rule.RuleModule = {
@@ -37,6 +36,11 @@ const rule: Rule.RuleModule = {
         type: 'object',
         properties: {
           checkKeyCodeForSafari: { type: 'boolean' },
+          guardFunctions: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
         },
         additionalProperties: false,
       },
@@ -53,6 +57,16 @@ const rule: Rule.RuleModule = {
       'checkKeyCodeForSafari' in rawOption &&
       (rawOption as Record<string, unknown>)['checkKeyCodeForSafari'] === false
     );
+    const guardFunctions =
+      rawOption !== null &&
+      rawOption !== undefined &&
+      typeof rawOption === 'object' &&
+      'guardFunctions' in rawOption &&
+      Array.isArray((rawOption as Record<string, unknown>)['guardFunctions'])
+        ? ((rawOption as Record<string, unknown>)['guardFunctions'] as unknown[]).filter(
+            (item): item is string => typeof item === 'string',
+          )
+        : [];
 
     /**
      * @param allowIsComposingGuard
@@ -86,6 +100,14 @@ const rule: Rule.RuleModule = {
             messageId: 'requireKeyCode229',
           });
         }
+        return;
+      }
+
+      if (
+        allowIsComposingGuard &&
+        guardFunctions.length > 0 &&
+        hasGuardFunctionCall({ node: body, guardFunctions })
+      ) {
         return;
       }
 

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -192,6 +192,47 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `input.addEventListener('keydown', (e) => { if (e.isComposing) return; if (e.key === 'Escape') close(); });`,
     },
+    // ── guardFunctions option ──────────────────────────────────────────────────
+    // basic: named guard function exempts keydown Enter check
+    {
+      code: `input.addEventListener('keydown', (e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); });`,
+      options: [{ guardFunctions: ["guardIsComposing"] }],
+    },
+    // keyup
+    {
+      code: `input.addEventListener('keyup', (e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); });`,
+      options: [{ guardFunctions: ["guardIsComposing"] }],
+    },
+    // onkeydown assignment
+    {
+      code: `input.onkeydown = (e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); };`,
+      options: [{ guardFunctions: ["guardIsComposing"] }],
+    },
+    // JSX onKeyDown
+    {
+      code: `<input onKeyDown={(e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); }} />;`,
+      options: [{ guardFunctions: ["guardIsComposing"] }],
+    },
+    // multiple guard function names — second name matches
+    {
+      code: `input.addEventListener('keydown', (e) => { if (isComposingGuard(e)) return; if (e.key === 'Enter') submit(); });`,
+      options: [{ guardFunctions: ["guardIsComposing", "isComposingGuard"] }],
+    },
+    // negated guard: if (!guardIsComposing(e)) — still recognised
+    {
+      code: `input.addEventListener('keydown', (e) => { if (!guardIsComposing(e)) return; if (e.key === 'Enter') submit(); });`,
+      options: [{ guardFunctions: ["guardIsComposing"] }],
+    },
+    // combined with checkKeyCodeForSafari: false — no requireKeyCode229 report
+    {
+      code: `input.addEventListener('keydown', (e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); });`,
+      options: [{ guardFunctions: ["guardIsComposing"], checkKeyCodeForSafari: false }],
+    },
+    // compound condition with guard function: if (guardIsComposing(e) && …)
+    {
+      code: `input.addEventListener('keydown', (e) => { if (guardIsComposing(e) && !e.shiftKey) return; if (e.key === 'Enter') submit(); });`,
+      options: [{ guardFunctions: ["guardIsComposing"] }],
+    },
   ],
 
   invalid: [
@@ -537,6 +578,23 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `<input onKeyPress={(e) => { switch(e.keyCode) { case 13: submit(); break; } }} />;`,
       errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onKeyPress' } }],
+    },
+    // ── guardFunctions — guard not in the list → still flagged ────────────────
+    {
+      code: `input.addEventListener('keydown', (e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); });`,
+      errors: [{ messageId: "requireImeSafeSubmit", data: { eventName: "keydown" } }],
+    },
+    // guardFunctions with keypress — keypress is deprecated regardless
+    {
+      code: `input.addEventListener('keypress', (e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); });`,
+      options: [{ guardFunctions: ["guardIsComposing"] }],
+      errors: [{ messageId: "keypressProhibited", data: { eventName: "keypress" } }],
+    },
+    // guard function called outside an IfStatement test — not recognised as a guard
+    {
+      code: `input.addEventListener('keydown', (e) => { guardIsComposing(e); if (e.key === 'Enter') submit(); });`,
+      options: [{ guardFunctions: ["guardIsComposing"] }],
+      errors: [{ messageId: "requireImeSafeSubmit", data: { eventName: "keydown" } }],
     },
     // ── JSX FunctionExpression (function keyword, not arrow) ─────────────────
     {


### PR DESCRIPTION
## Summary

- Add `guardFunctions` option — users can list custom IME guard helper function names, which the rule treats as equivalent to an `e.isComposing` guard
- Enforce `no-shadow` and no-single-character-variable naming in `helpers.ts`
- Fix Markdown semantics: replace misused blockquotes with plain paragraphs (README) and GFM alerts (docs)

Closes #1

## Test plan

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Verify `guardFunctions` option works end-to-end in a consuming project

🤖 Generated with [Claude Code](https://claude.com/claude-code)