### PR TITLE
Release v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Try it in the [playground](https://github.com/hiroya-uga/eslint-plugin-ime-safe-
 
 When checking for the Enter key in `keydown`/`keyup` handlers to submit a form, users typing with an IME experience broken input: pressing Enter to **confirm IME candidates** accidentally triggers form submission before the composition is complete.
 
-There are two correct approaches:
+There are three correct approaches:
 
 ```js
 // ✅ Option 1: guard with e.isComposing + e.keyCode === 229 (covers Safari)
@@ -39,6 +39,11 @@ input.addEventListener('keydown', (e) => {
 form.addEventListener('submit', (e) => {
   e.preventDefault();
   submit();
+});
+
+// ✅ Option 3: require a modifier key — IME cannot be composing while Ctrl/Meta/Shift/Alt is held
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submit();
 });
 
 // ❌ Bad — breaks IME input
@@ -154,7 +159,7 @@ module.exports = {
 
 ### Detected patterns
 
-- `element.addEventListener('keydown' \| 'keyup', handler)` where handler checks `e.key === 'Enter'`, `e.code === 'Enter'`, `e.keyCode === 13`, or `e.which === 13` **without** an `e.isComposing` guard
+- `element.addEventListener('keydown' \| 'keyup', handler)` where handler checks `e.key === 'Enter'`, `e.code === 'Enter'`, `e.keyCode === 13`, or `e.which === 13` **without** an `e.isComposing` guard or a modifier key condition (`e.ctrlKey`, `e.metaKey`, `e.shiftKey`, `e.altKey`)
 - `element.addEventListener('keypress', handler)` where handler checks for Enter — always flagged (`keypress` is deprecated)
 - `element.onkeydown` / `element.onkeyup` / `element.onkeypress` assignments
 - JSX `onKeyDown` / `onKeyUp` / `onKeyPress` props

--- a/docs/rules/require-ime-safe-submit.md
+++ b/docs/rules/require-ime-safe-submit.md
@@ -6,10 +6,11 @@ Require IME-safe form submission. Disallow Enter key detection in `keydown`/`key
 
 When a `keydown` or `keyup` handler checks for the Enter key without guarding against IME composition, users typing with an IME experience broken input: pressing Enter to confirm IME candidates fires `keydown` before `compositionend`, causing accidental form submission mid-input.
 
-This rule requires one of two correct approaches:
+This rule requires one of three correct approaches:
 
 1. **`e.isComposing` guard** — skip the handler body while IME composition is in progress
 2. **Form `submit` event** — fires only after composition completes; no guard needed
+3. **Modifier key condition** — when a modifier key (`Ctrl`, `Meta`, `Shift`, `Alt`) is required alongside Enter, IME composition cannot be active; no guard is needed
 
 `keypress` is prohibited entirely because it is deprecated. Use `keydown` with an `e.isComposing` guard instead.
 
@@ -61,6 +62,16 @@ input.addEventListener('keypress', (e) => {
   if (e.isComposing) return;
   if (e.key === 'Enter') submit();
 });
+
+// Modifier negation is not a guard — IME Enter has shiftKey === false, so !e.shiftKey is true
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) submit();
+});
+
+// OR with modifier is not a guard — plain Enter (no modifier) still fires
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' || e.ctrlKey) submit();
+});
 ```
 
 ```jsx
@@ -86,6 +97,23 @@ input.addEventListener('keydown', (e) => {
 form.addEventListener('submit', (e) => {
   e.preventDefault();
   submit();
+});
+
+// ✅ Option 3: modifier key — IME cannot be composing when Ctrl/Meta/Shift/Alt is held
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && e.ctrlKey) submit();
+});
+
+// ✅ Multiple modifiers with || are also recognised
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submit();
+});
+
+// ✅ Outer if with modifier is also recognised
+input.addEventListener('keydown', (e) => {
+  if (e.ctrlKey) {
+    if (e.key === 'Enter') submit();
+  }
 });
 
 // ✅ keydown for non-submission purposes is fine
@@ -130,6 +158,8 @@ input.addEventListener('keydown', (e) => {
 | `e.isComposing \|\| e.keyCode === 229` guard in `keydown`/`keyup` | Default — covers both standard browsers and Safari |
 | `e.isComposing` guard alone (with `checkKeyCodeForSafari: false`) | Author opted out of Safari check |
 | Guard function call in `IfStatement` (with `guardFunctions` option) | Function is declared as an equivalent IME guard |
+| Enter key check combined with a modifier via `&&` (`e.ctrlKey`, `e.metaKey`, `e.shiftKey`, `e.altKey`) | IME cannot be composing while a modifier key is held |
+| Outer `if` whose test is a positive modifier expression, Enter check inside the body | Same reasoning — modifier held means no IME composition |
 | Enter check inside a nested function | Out of scope for the keydown handler |
 | Named function reference (`addEventListener('keydown', fn)`) | Cannot statically analyze external function bodies |
 

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -202,6 +202,91 @@ export const hasIsComposingCheck = (node: Node | null | undefined) =>
     node,
   });
 
+const MODIFIER_KEY_PROPS = ['ctrlKey', 'metaKey', 'shiftKey', 'altKey'] as const;
+
+const isModifierKeyMemberExpression = (node: Node) =>
+  MODIFIER_KEY_PROPS.some((prop) => isMemberWithProp({ node, propName: prop }));
+
+/**
+ * Returns true only for expressions that positively assert a modifier key is
+ * held — i.e., the IME cannot be composing. Negated checks like `!e.ctrlKey`
+ * are intentionally rejected.
+ *
+ *   e.ctrlKey                   → true
+ *   e.ctrlKey || e.metaKey      → true
+ *   !e.ctrlKey                  → false  (does not prevent IME)
+ *   e.key === 'Enter'           → false
+ */
+const isPositiveModifierExpression = (node: Node): boolean => {
+  if (isModifierKeyMemberExpression(node)) {
+    return true;
+  }
+  if (node.type === 'LogicalExpression' && node.operator === '||') {
+    return isPositiveModifierExpression(node.left) && isPositiveModifierExpression(node.right);
+  }
+  return false;
+};
+
+/**
+ * Returns true if the LogicalExpression subtree (connected by &&) has one side
+ * containing an Enter key check and the other side being a positive modifier
+ * expression. Recursively handles chained &&.
+ *
+ *   e.key === 'Enter' && e.ctrlKey               → true
+ *   e.ctrlKey && e.key === 'Enter'               → true
+ *   e.key === 'Enter' && (e.ctrlKey || e.metaKey) → true
+ *   e.key === 'Enter' && !e.shiftKey              → false (!modifier ≠ IME guard)
+ */
+const andChainHasEnterWithModifier = (node: Node): boolean => {
+  if (node.type !== 'LogicalExpression' || node.operator !== '&&') {
+    return false;
+  }
+  const { left, right } = node;
+  const leftHasEnter = walkAst({ predicate: isEnterKeyNode, node: left });
+  const rightHasEnter = walkAst({ predicate: isEnterKeyNode, node: right });
+
+  if (leftHasEnter && isPositiveModifierExpression(right)) {
+    return true;
+  }
+  if (rightHasEnter && isPositiveModifierExpression(left)) {
+    return true;
+  }
+
+  return andChainHasEnterWithModifier(left) || andChainHasEnterWithModifier(right);
+};
+
+/**
+ * Returns true if the handler body contains a modifier-key guard that makes
+ * IME composition impossible. When a modifier key (Ctrl, Meta, Shift, Alt) is
+ * held, the IME cannot be in composition state, so e.isComposing is always
+ * false and no guard is needed.
+ *
+ * Pattern A — Enter + modifier in the same && condition:
+ *   if (e.key === 'Enter' && e.ctrlKey) …
+ *   if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) …
+ *
+ * Pattern B — outer if whose test is a positive modifier expression, with an
+ * Enter check inside the body:
+ *   if (e.ctrlKey) { if (e.key === 'Enter') … }
+ */
+export const hasModifierKeyGuard = (node: Node | null | undefined) =>
+  walkAst({
+    predicate: (candidateNode) => {
+      if (candidateNode.type !== 'IfStatement') {
+        return false;
+      }
+
+      const { test, consequent } = candidateNode;
+
+      if (andChainHasEnterWithModifier(test)) {
+        return true;
+      }
+
+      return isPositiveModifierExpression(test) && containsEnterKeyCheck(consequent);
+    },
+    node,
+  });
+
 /**
  * Returns true if the handler body contains an IfStatement whose condition
  * calls one of the specified guard function names. This allows users to

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -7,6 +7,7 @@ import {
   hasGuardFunctionCall,
   hasIsComposingCheck,
   hasKeyCode229Check,
+  hasModifierKeyGuard,
   JSX_KEY_EVENTS,
   KEY_EVENTS,
 } from './helpers';
@@ -108,6 +109,10 @@ const rule: Rule.RuleModule = {
         guardFunctions.length > 0 &&
         hasGuardFunctionCall({ node: body, guardFunctions })
       ) {
+        return;
+      }
+
+      if (allowIsComposingGuard && hasModifierKeyGuard(body)) {
         return;
       }
 

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -192,6 +192,59 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `input.addEventListener('keydown', (e) => { if (e.isComposing) return; if (e.key === 'Escape') close(); });`,
     },
+    // ── modifier key guard — IME cannot compose while a modifier is held ────────
+    // Pattern A: Enter + modifier in same && condition
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && e.ctrlKey) submit(); });`,
+    },
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && e.metaKey) submit(); });`,
+    },
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && e.shiftKey) submit(); });`,
+    },
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && e.altKey) submit(); });`,
+    },
+    // reversed operand order
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.ctrlKey && e.key === 'Enter') submit(); });`,
+    },
+    // multiple modifiers with ||
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submit(); });`,
+    },
+    // legacy keyCode
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.keyCode === 13 && e.ctrlKey) submit(); });`,
+    },
+    // keyup
+    {
+      code: `input.addEventListener('keyup', (e) => { if (e.key === 'Enter' && e.ctrlKey) submit(); });`,
+    },
+    // onkeydown assignment
+    {
+      code: `input.onkeydown = (e) => { if (e.key === 'Enter' && e.ctrlKey) submit(); };`,
+    },
+    // JSX
+    {
+      code: `<input onKeyDown={(e) => { if (e.key === 'Enter' && e.ctrlKey) submitForm(); }} />;`,
+    },
+    {
+      code: `<input onKeyUp={(e) => { if (e.key === 'Enter' && e.ctrlKey) submitForm(); }} />;`,
+    },
+    // Pattern B: outer if with modifier, Enter check inside
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.ctrlKey) { if (e.key === 'Enter') submit(); } });`,
+    },
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.ctrlKey) { switch(e.key) { case 'Enter': submit(); break; } } });`,
+    },
+    // checkKeyCodeForSafari: false — modifier guard still exempts
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && e.ctrlKey) submit(); });`,
+      options: [{ checkKeyCodeForSafari: false }],
+    },
     // ── guardFunctions option ──────────────────────────────────────────────────
     // basic: named guard function exempts keydown Enter check
     {
@@ -578,6 +631,22 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `<input onKeyPress={(e) => { switch(e.keyCode) { case 13: submit(); break; } }} />;`,
       errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onKeyPress' } }],
+    },
+    // ── modifier key — patterns that are NOT safe ────────────────────────────
+    // || instead of && — Enter without modifier still triggers
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.ctrlKey) submit(); });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keydown' } }],
+    },
+    // Enter check is the outer if, modifier check is inside — still unsafe
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter') { if (e.ctrlKey) submit(); } });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keydown' } }],
+    },
+    // keypress with modifier guard — keypress is always prohibited
+    {
+      code: `input.addEventListener('keypress', (e) => { if (e.key === 'Enter' && e.ctrlKey) submit(); });`,
+      errors: [{ messageId: 'keypressProhibited', data: { eventName: 'keypress' } }],
     },
     // ── guardFunctions — guard not in the list → still flagged ────────────────
     {


### PR DESCRIPTION
Related to #2 

## Fix

- Add hasModifierKeyGuard() to helpers.ts: detects Enter+modifier && patterns and outer-if modifier patterns as IME-safe (modifier held → IME inactive)
- Supports ctrlKey, metaKey, shiftKey, altKey; rejects negated checks (!e.ctrlKey)
- Update docs/rules/require-ime-safe-submit.md and README.md