### PR TITLE
Release v1.2.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["CONTENTEDITABLE"]
+}

--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ When checking for the Enter key in `keydown`/`keyup` handlers to submit a form, 
 There are three correct approaches:
 
 ```js
-// ✅ Option 1: guard with e.isComposing + e.keyCode === 229 (covers Safari)
-input.addEventListener('keydown', (e) => {
-  if (e.isComposing || e.keyCode === 229) return;
-  if (e.key === 'Enter') submit();
-});
-
-// ✅ Option 2: use the form's submit event (fires after composition ends)
+// ✅ Option 1: use the form's submit event (fires after composition ends — no guard needed)
 form.addEventListener('submit', (e) => {
   e.preventDefault();
   submit();
 });
 
-// ✅ Option 3: require a modifier key — IME cannot be composing while Ctrl/Meta/Shift/Alt is held
+// ✅ Option 2: require a modifier key — IME cannot be composing while Ctrl/Meta/Shift/Alt is held
 input.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submit();
+});
+
+// ✅ Option 3: guard with e.isComposing + e.keyCode === 229 (covers Safari)
+input.addEventListener('keydown', (e) => {
+  if (e.isComposing || e.keyCode === 229) return;
+  if (e.key === 'Enter') submit();
 });
 
 // ❌ Bad — breaks IME input

--- a/docs/rules/require-ime-safe-submit.md
+++ b/docs/rules/require-ime-safe-submit.md
@@ -8,9 +8,9 @@ When a `keydown` or `keyup` handler checks for the Enter key without guarding ag
 
 This rule requires one of three correct approaches:
 
-1. **`e.isComposing` guard** — skip the handler body while IME composition is in progress
-2. **Form `submit` event** — fires only after composition completes; no guard needed
-3. **Modifier key condition** — when a modifier key (`Ctrl`, `Meta`, `Shift`, `Alt`) is required alongside Enter, IME composition cannot be active; no guard is needed
+1. **Form `submit` event** — fires only after composition completes; no guard needed
+2. **Modifier key condition** — when a modifier key (`Ctrl`, `Meta`, `Shift`, `Alt`) is required alongside Enter, IME composition cannot be active; no guard is needed
+3. **`e.isComposing` guard** — skip the handler body while IME composition is in progress
 
 `keypress` is prohibited entirely because it is deprecated. Use `keydown` with an `e.isComposing` guard instead.
 
@@ -87,19 +87,13 @@ input.addEventListener('keydown', (e) => {
 ```js
 /* eslint ime-safe-form/require-ime-safe-submit: "warn" */
 
-// ✅ Option 1: e.isComposing + e.keyCode === 229 guard (covers Safari)
-input.addEventListener('keydown', (e) => {
-  if (e.isComposing || e.keyCode === 229) return;
-  if (e.key === 'Enter') submit();
-});
-
-// ✅ Option 2: use the form's submit event
+// ✅ Option 1: use the form's submit event (fires after composition ends — no guard needed)
 form.addEventListener('submit', (e) => {
   e.preventDefault();
   submit();
 });
 
-// ✅ Option 3: modifier key — IME cannot be composing when Ctrl/Meta/Shift/Alt is held
+// ✅ Option 2: modifier key — IME cannot be composing when Ctrl/Meta/Shift/Alt is held
 input.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && e.ctrlKey) submit();
 });
@@ -114,6 +108,12 @@ input.addEventListener('keydown', (e) => {
   if (e.ctrlKey) {
     if (e.key === 'Enter') submit();
   }
+});
+
+// ✅ Option 3: e.isComposing + e.keyCode === 229 guard (covers Safari)
+input.addEventListener('keydown', (e) => {
+  if (e.isComposing || e.keyCode === 229) return;
+  if (e.key === 'Enter') submit();
 });
 
 // ✅ keydown for non-submission purposes is fine

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -11,11 +11,70 @@ export interface JSXExpressionContainer extends BaseNode {
   expression: Node | null;
 }
 
+export interface JSXSpreadAttribute extends BaseNode {
+  type: 'JSXSpreadAttribute';
+}
+
+export interface JSXMemberExpression extends BaseNode {
+  type: 'JSXMemberExpression';
+}
+
+export interface JSXOpeningElement extends BaseNode {
+  type: 'JSXOpeningElement';
+  name: JSXIdentifier | JSXMemberExpression;
+  attributes: Array<JSXAttribute | JSXSpreadAttribute>;
+}
+
 export interface JSXAttribute extends BaseNode {
   type: 'JSXAttribute';
   name: JSXIdentifier;
-  value: JSXExpressionContainer | null;
+  value: JSXExpressionContainer | { type: 'Literal'; value: unknown } | null;
+  parent: JSXOpeningElement;
 }
+
+export const IME_CAPABLE_ELEMENTS = new Set(['input', 'textarea', 'select']);
+
+const CONTENTEDITABLE_PROPS = new Set(['contenteditable', 'contentEditable']);
+
+export const isImeCapableJsxElement = ({
+  openingElement,
+  allowComponents,
+}: {
+  openingElement: JSXOpeningElement;
+  allowComponents: string[];
+}) => {
+  const { name: nameNode, attributes } = openingElement;
+
+  if (nameNode.type !== 'JSXIdentifier') {
+    return true;
+  }
+
+  const elementName = nameNode.name;
+
+  if (/^[A-Z]/.test(elementName)) {
+    return !allowComponents.includes(elementName);
+  }
+
+  if (IME_CAPABLE_ELEMENTS.has(elementName)) {
+    return true;
+  }
+
+  return attributes.some((attr) => {
+    if (attr.type !== 'JSXAttribute') {
+      return false;
+    }
+
+    if (attr.name.type !== 'JSXIdentifier' || !CONTENTEDITABLE_PROPS.has(attr.name.name)) {
+      return false;
+    }
+
+    if (attr.value !== null && attr.value.type === 'Literal' && attr.value.value === 'false') {
+      return false;
+    }
+
+    return true;
+  });
+};
 
 export const FUNCTION_TYPES = new Set(['FunctionExpression', 'ArrowFunctionExpression', 'FunctionDeclaration']);
 

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -32,9 +32,12 @@ export interface JSXAttribute extends BaseNode {
   parent: JSXOpeningElement;
 }
 
+export const isString = (item: unknown): item is string => typeof item === 'string';
+
 export const IME_CAPABLE_ELEMENTS = new Set(['input', 'textarea', 'select']);
 
 const CONTENTEDITABLE_PROPS = new Set(['contenteditable', 'contentEditable']);
+const PASCAL_CASE_PATTERN = /^[A-Z]/;
 
 export const isImeCapableJsxElement = ({
   openingElement,
@@ -51,7 +54,7 @@ export const isImeCapableJsxElement = ({
 
   const elementName = nameNode.name;
 
-  if (/^[A-Z]/.test(elementName)) {
+  if (PASCAL_CASE_PATTERN.test(elementName)) {
     return !allowComponents.includes(elementName);
   }
 

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -9,6 +9,7 @@ import {
   hasKeyCode229Check,
   hasModifierKeyGuard,
   isImeCapableJsxElement,
+  isString,
   JSX_KEY_EVENTS,
   KEY_EVENTS,
 } from './helpers';
@@ -22,6 +23,19 @@ const messages = {
   requireKeyCode229:
     "In Safari, compositionend fires before keydown, so e.isComposing is false when Enter confirms IME. Add '|| e.keyCode === 229' to the guard: 'if (e.isComposing || e.keyCode === 229) return;'.",
 } as const;
+
+const resolveStringArrayOption = ({ rawOption, key }: { rawOption: unknown; key: string }): string[] => {
+  if (
+    rawOption !== null &&
+    rawOption !== undefined &&
+    typeof rawOption === 'object' &&
+    key in rawOption &&
+    Array.isArray((rawOption as Record<string, unknown>)[key])
+  ) {
+    return ((rawOption as Record<string, unknown>)[key] as unknown[]).filter(isString);
+  }
+  return [];
+};
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -64,26 +78,8 @@ const rule: Rule.RuleModule = {
       'checkKeyCodeForSafari' in rawOption &&
       (rawOption as Record<string, unknown>)['checkKeyCodeForSafari'] === false
     );
-    const guardFunctions =
-      rawOption !== null &&
-      rawOption !== undefined &&
-      typeof rawOption === 'object' &&
-      'guardFunctions' in rawOption &&
-      Array.isArray((rawOption as Record<string, unknown>)['guardFunctions'])
-        ? ((rawOption as Record<string, unknown>)['guardFunctions'] as unknown[]).filter(
-            (item): item is string => typeof item === 'string',
-          )
-        : [];
-    const allowComponents =
-      rawOption !== null &&
-      rawOption !== undefined &&
-      typeof rawOption === 'object' &&
-      'allowComponents' in rawOption &&
-      Array.isArray((rawOption as Record<string, unknown>)['allowComponents'])
-        ? ((rawOption as Record<string, unknown>)['allowComponents'] as unknown[]).filter(
-            (item): item is string => typeof item === 'string',
-          )
-        : [];
+    const guardFunctions = resolveStringArrayOption({ rawOption, key: 'guardFunctions' });
+    const allowComponents = resolveStringArrayOption({ rawOption, key: 'allowComponents' });
 
     /**
      * @param allowIsComposingGuard
@@ -120,11 +116,7 @@ const rule: Rule.RuleModule = {
         return;
       }
 
-      if (
-        allowIsComposingGuard &&
-        guardFunctions.length > 0 &&
-        hasGuardFunctionCall({ node: body, guardFunctions })
-      ) {
+      if (allowIsComposingGuard && guardFunctions.length > 0 && hasGuardFunctionCall({ node: body, guardFunctions })) {
         return;
       }
 

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -8,6 +8,7 @@ import {
   hasIsComposingCheck,
   hasKeyCode229Check,
   hasModifierKeyGuard,
+  isImeCapableJsxElement,
   JSX_KEY_EVENTS,
   KEY_EVENTS,
 } from './helpers';
@@ -42,6 +43,11 @@ const rule: Rule.RuleModule = {
             items: { type: 'string' },
             uniqueItems: true,
           },
+          allowComponents: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
         },
         additionalProperties: false,
       },
@@ -65,6 +71,16 @@ const rule: Rule.RuleModule = {
       'guardFunctions' in rawOption &&
       Array.isArray((rawOption as Record<string, unknown>)['guardFunctions'])
         ? ((rawOption as Record<string, unknown>)['guardFunctions'] as unknown[]).filter(
+            (item): item is string => typeof item === 'string',
+          )
+        : [];
+    const allowComponents =
+      rawOption !== null &&
+      rawOption !== undefined &&
+      typeof rawOption === 'object' &&
+      'allowComponents' in rawOption &&
+      Array.isArray((rawOption as Record<string, unknown>)['allowComponents'])
+        ? ((rawOption as Record<string, unknown>)['allowComponents'] as unknown[]).filter(
             (item): item is string => typeof item === 'string',
           )
         : [];
@@ -178,6 +194,10 @@ const rule: Rule.RuleModule = {
       JSXAttribute(rawNode: unknown) {
         const node = rawNode as JSXAttribute;
         if (node.name.type !== 'JSXIdentifier' || !JSX_KEY_EVENTS.has(node.name.name)) {
+          return;
+        }
+
+        if (!isImeCapableJsxElement({ openingElement: node.parent, allowComponents })) {
           return;
         }
 

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -245,6 +245,44 @@ tester.run('require-ime-safe-submit', rule, {
       code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && e.ctrlKey) submit(); });`,
       options: [{ checkKeyCodeForSafari: false }],
     },
+    // ── allowComponents option — named components are not flagged ─────────────
+    {
+      code: `<MyInput onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      options: [{ allowComponents: ['MyInput'] }],
+    },
+    {
+      code: `<MyInput onKeyUp={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      options: [{ allowComponents: ['MyInput'] }],
+    },
+    {
+      code: `<MyInput onKeyPress={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      options: [{ allowComponents: ['MyInput'] }],
+    },
+    // multiple names — second matches
+    {
+      code: `<SearchField onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      options: [{ allowComponents: ['MyInput', 'SearchField'] }],
+    },
+    // ── JSX non-input HTML elements — not IME-capable, not flagged ────────────
+    {
+      code: `<div onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
+    {
+      code: `<button onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
+    {
+      code: `<span onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
+    {
+      code: `<div role="button" tabIndex={0} onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
+    // contentEditable="false" — explicitly not editable
+    {
+      code: `<div contentEditable="false" onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
+    {
+      code: `<div contenteditable="false" onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
     // ── guardFunctions option ──────────────────────────────────────────────────
     // basic: named guard function exempts keydown Enter check
     {
@@ -664,6 +702,39 @@ tester.run('require-ime-safe-submit', rule, {
       code: `input.addEventListener('keydown', (e) => { guardIsComposing(e); if (e.key === 'Enter') submit(); });`,
       options: [{ guardFunctions: ["guardIsComposing"] }],
       errors: [{ messageId: "requireImeSafeSubmit", data: { eventName: "keydown" } }],
+    },
+    // ── JSX IME-capable elements beyond <input> ───────────────────────────────
+    {
+      code: `<textarea onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
+    },
+    {
+      code: `<select onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
+    },
+    // contentEditable — makes non-input elements IME-capable
+    {
+      code: `<div contentEditable onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
+    },
+    {
+      code: `<div contentEditable="true" onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
+    },
+    {
+      code: `<div contenteditable onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
+    },
+    // PascalCase component — warned by default (cannot inspect rendered output)
+    {
+      code: `<MyInput onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
+    },
+    // allowComponents — unlisted component is still flagged
+    {
+      code: `<OtherInput onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      options: [{ allowComponents: ['MyInput'] }],
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
     },
     // ── JSX FunctionExpression (function keyword, not arrow) ─────────────────
     {


### PR DESCRIPTION
Related #2

## Summary

- JSX の `onKeyDown` / `onKeyUp` / `onKeyPress` を IME 入力を受け取れる要素のみに制限（`<div>` などの非 input 要素は警告しない）
- `<input>` / `<textarea>` / `<select>` は引き続き警告対象
- `contentEditable` 属性を持つ要素も警告対象（`contentEditable="false"` は除外）
- PascalCase コンポーネントはデフォルトで警告。新オプション `allowComponents: string[]` で個別に除外可能
- `addEventListener` / `element.onkeydown` パターンは静的解析不可のため対象外（既存の挙動を維持）



## Test plan

- [x] `npm test` パス
- [x] `npm run typecheck` パス