### PR TITLE
Extend key detection to all key checks (v1.3.0)

### DIFF
--- a/docs/rules/require-ime-safe-submit.md
+++ b/docs/rules/require-ime-safe-submit.md
@@ -1,15 +1,15 @@
 # require-ime-safe-submit
 
-Require IME-safe form submission. Disallow Enter key detection in `keydown`/`keyup` without an `e.isComposing` guard, and prohibit `keypress` entirely.
+Require IME-safe form submission. Disallow key checks in `keydown`/`keyup` without an `e.isComposing` guard, and prohibit `keypress` entirely.
 
 ## Rule Details
 
-When a `keydown` or `keyup` handler checks for the Enter key without guarding against IME composition, users typing with an IME experience broken input: pressing Enter to confirm IME candidates fires `keydown` before `compositionend`, causing accidental form submission mid-input.
+When a `keydown` or `keyup` handler checks a key property (`e.key`, `e.code`, `e.keyCode`, `e.which`) without guarding against IME composition, users typing with an IME experience broken input. For example, pressing Enter to confirm IME candidates fires `keydown` before `compositionend`, and pressing Escape to cancel IME input fires `keydown` while `e.isComposing` is still `true` — both can trigger unintended side effects.
 
 This rule requires one of three correct approaches:
 
 1. **Form `submit` event** — fires only after composition completes; no guard needed
-2. **Modifier key condition** — when a modifier key (`Ctrl`, `Meta`, `Shift`, `Alt`) is required alongside Enter, IME composition cannot be active; no guard is needed
+2. **Modifier key condition** — when a modifier key (`Ctrl`, `Meta`, `Shift`, `Alt`) is required alongside the key check, IME composition cannot be active; no guard is needed
 3. **`e.isComposing` guard** — skip the handler body while IME composition is in progress
 
 `keypress` is prohibited entirely because it is deprecated. Use `keydown` with an `e.isComposing` guard instead.
@@ -52,6 +52,16 @@ input.onkeydown = (e) => {
   if (e.key === 'Enter') submit();
 };
 
+// Non-Enter key checks have the same IME race condition
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeDialog(); // fires during IME composition — Escape cancels the candidate
+});
+input.addEventListener('keydown', (e) => {
+  switch (e.key) {
+    case 'ArrowDown': navigate(); break; // fires during IME candidate navigation
+  }
+});
+
 // keypress — always prohibited (deprecated event)
 input.addEventListener('keypress', (e) => {
   if (e.key === 'Enter') submit();
@@ -75,7 +85,7 @@ input.addEventListener('keydown', (e) => {
 ```
 
 ```jsx
-// JSX — onKeyDown without isComposing guard
+// JSX — onKeyDown without isComposing guard on an IME-capable element
 <input onKeyDown={(e) => { if (e.key === 'Enter') submitForm(); }} />
 
 // JSX — onKeyPress always prohibited
@@ -116,8 +126,9 @@ input.addEventListener('keydown', (e) => {
   if (e.key === 'Enter') submit();
 });
 
-// ✅ keydown for non-submission purposes is fine
+// ✅ Non-Enter key with isComposing guard
 input.addEventListener('keydown', (e) => {
+  if (e.isComposing || e.keyCode === 229) return;
   if (e.key === 'Escape') closeDialog();
 });
 
@@ -136,20 +147,37 @@ input.addEventListener('keydown', (e) => {
 <form onSubmit={(e) => { e.preventDefault(); submitForm(); }}>
   ...
 </form>
+
+// ✅ JSX — non-IME-capable element; no guard needed (key checks on div/button do not affect IME input)
+<div onKeyDown={(e) => { if (e.key === 'Escape') closeDialog(); }} />
+<button onKeyDown={(e) => { if (e.key === 'ArrowDown') navigate(); }} />
 ```
 
 ## Detected Patterns
 
 | Pattern | Example |
 |---|---|
-| `addEventListener('keydown' \| 'keyup', handler)` | `el.addEventListener('keydown', e => { if (e.key === 'Enter') … })` |
+| `addEventListener('keydown' \| 'keyup', handler)` | `el.addEventListener('keydown', e => { if (e.key === '…') … })` |
 | `addEventListener('keypress', handler)` | Always flagged (deprecated event) |
-| `onkeydown` / `onkeyup` / `onkeypress` property assignment | `el.onkeydown = e => { if (e.key === 'Enter') … }` |
-| JSX `onKeyDown` / `onKeyUp` prop | `<input onKeyDown={e => { if (e.key === 'Enter') … }} />` |
+| `onkeydown` / `onkeyup` / `onkeypress` property assignment | `el.onkeydown = e => { if (e.key === '…') … }` |
+| JSX `onKeyDown` / `onKeyUp` prop on IME-capable elements | `<input onKeyDown={e => { if (e.key === '…') … }} />` |
 | JSX `onKeyPress` prop | Always flagged (deprecated event) |
-| `e.code === 'Enter'` / `e.code !== 'Enter'` | `if (e.code === 'Enter') …` / `if (e.code !== 'Enter') return` |
-| Legacy `keyCode === 13` / `which === 13` (and `!==` / `!=`) | `if (e.keyCode === 13) …` / `if (e.keyCode !== 13) return` |
+| `e.key` / `e.code` comparison (any value) | `if (e.key === 'Enter') …` / `if (e.key !== 'Escape') return` |
+| Legacy `e.keyCode` / `e.which` comparison (any value) | `if (e.keyCode === 13) …` / `if (e.keyCode !== 13) return` |
 | `switch` on `e.key` / `e.code` / `e.keyCode` / `e.which` | `switch(e.key) { case 'Enter': … }` |
+
+### IME-capable elements (JSX only)
+
+The JSX patterns (`onKeyDown`, `onKeyUp`, `onKeyPress`) are only checked on elements where IME input is possible. Key checks on other elements (such as `<div>` or `<button>`) are not flagged.
+
+| Element | Flagged |
+|---|---|
+| `<input>`, `<textarea>`, `<select>` | Yes |
+| Any element with `contentEditable` / `contenteditable` (not `"false"`) | Yes |
+| PascalCase components (e.g. `<MyInput>`) | Yes (rendered output unknown) |
+| Other elements (`<div>`, `<button>`, `<span>`, …) | No |
+
+Use the [`allowComponents`](#allowcomponents-default-) option to exempt specific PascalCase components you know are not IME-capable.
 
 ### Not flagged
 
@@ -158,17 +186,18 @@ input.addEventListener('keydown', (e) => {
 | `e.isComposing \|\| e.keyCode === 229` guard in `keydown`/`keyup` | Default — covers both standard browsers and Safari |
 | `e.isComposing` guard alone (with `checkKeyCodeForSafari: false`) | Author opted out of Safari check |
 | Guard function call in `IfStatement` (with `guardFunctions` option) | Function is declared as an equivalent IME guard |
-| Enter key check combined with a modifier via `&&` (`e.ctrlKey`, `e.metaKey`, `e.shiftKey`, `e.altKey`) | IME cannot be composing while a modifier key is held |
-| Outer `if` whose test is a positive modifier expression, Enter check inside the body | Same reasoning — modifier held means no IME composition |
-| Enter check inside a nested function | Out of scope for the keydown handler |
+| Key check combined with a modifier via `&&` (`e.ctrlKey`, `e.metaKey`, `e.shiftKey`, `e.altKey`) | IME cannot be composing while a modifier key is held |
+| Outer `if` whose test is a positive modifier expression, key check inside the body | Same reasoning — modifier held means no IME composition |
+| Key check inside a nested function | Out of scope for the keydown handler |
 | Named function reference (`addEventListener('keydown', fn)`) | Cannot statically analyze external function bodies |
+| JSX key check on non-IME-capable element (`<div>`, `<button>`, etc.) | Element cannot receive IME input |
 
 ### Known limitations
 
 - **Ternary `isComposing` guard is not recognised.** Only `IfStatement` tests are checked. `e.isComposing ? null : (e.key === 'Enter' && submit())` will be flagged even though it is IME-safe. Use an `if` statement instead.
-- **`!==`/`!=` patterns in a block body are detected but not in isolation.** If the entire handler never reaches submission code after the Enter check, the flag may be a false positive. Use `// eslint-disable-next-line` for those rare cases.
-- **`isComposing` guard without early exit is not verified.** The rule recognises any `IfStatement` whose condition references `e.isComposing`, regardless of whether the body actually returns or throws. Code like `if (e.isComposing) console.log("composing")` (no `return`) satisfies the check even though it does not prevent Enter processing. Always pair the guard with `return` (or equivalent).
-- **Destructured event parameters are not detected.** If the event object is destructured in the handler signature, the rule cannot see the Enter key check and will not flag it. Write the handler as `(e) => { if (e.key === 'Enter') … }` rather than `({ key }) => { if (key === 'Enter') … }`.
+- **`!==`/`!=` patterns in a block body are detected but not in isolation.** If the entire handler never reaches the target code after the key check, the flag may be a false positive. Use `// eslint-disable-next-line` for those rare cases.
+- **`isComposing` guard without early exit is not verified.** The rule recognises any `IfStatement` whose condition references `e.isComposing`, regardless of whether the body actually returns or throws. Code like `if (e.isComposing) console.log("composing")` (no `return`) satisfies the check even though it does not prevent key processing. Always pair the guard with `return` (or equivalent).
+- **Destructured event parameters are not detected.** If the event object is destructured in the handler signature, the rule cannot see the key check and will not flag it. Write the handler as `(e) => { if (e.key === 'Enter') … }` rather than `({ key }) => { if (key === 'Enter') … }`.
 
   ```js
   // ⚠ Not flagged — use eslint-disable if intentional, or rewrite with (e) =>
@@ -176,6 +205,8 @@ input.addEventListener('keydown', (e) => {
     if (key === 'Enter') submit(); // missed by the rule
   });
   ```
+
+- **`addEventListener` and `onkeydown =` do not scope by element type.** The rule cannot determine the element the handler is attached to at static analysis time. Even if the handler is on a `<div>`, it will be flagged. Only JSX patterns benefit from element-type scoping.
 
 ## Options
 
@@ -215,6 +246,32 @@ Negated calls (`if (!guardIsComposing(e))`) and calls inside compound conditions
 > [!NOTE]
 > `guardFunctions` has no effect on `keypress` handlers — `keypress` is prohibited regardless of any guard.
 
+### `allowComponents` (default: `[]`)
+
+PascalCase JSX components (e.g. `<MyInput>`) are flagged by default because their rendered output is unknown. If a component is guaranteed not to receive IME input (for example, a custom button or a navigation widget), list it here to suppress the warning.
+
+```js
+// eslint.config.js
+export default [
+  {
+    ...imeSafeForm.configs.recommended,
+    rules: {
+      'ime-safe-form/require-ime-safe-submit': ['warn', {
+        allowComponents: ['ComboBox', 'NavigationMenu'],
+      }],
+    },
+  },
+];
+```
+
+```jsx
+// ✅ Exempted — no warning even without an isComposing guard
+<ComboBox onKeyDown={(e) => { if (e.key === 'ArrowDown') navigate(); }} />
+```
+
+> [!NOTE]
+> `allowComponents` only affects JSX patterns. `addEventListener` and `onkeydown =` are not scoped by element type and are always checked.
+
 ### `checkKeyCodeForSafari` (default: `true`)
 
 In Safari, `compositionend` fires **before** the final `keydown`, so `e.isComposing` is already `false` when Enter is pressed to confirm IME. Setting this option to `true` additionally requires `e.keyCode === 229` alongside `e.isComposing`:
@@ -231,7 +288,7 @@ export default [
 ];
 ```
 
-With `checkKeyCodeForSafari: true`, only the combined guard is accepted:
+With `checkKeyCodeForSafari: true`, only the combined guard is accepted for Enter key checks:
 
 ```js
 // ✅ Correct — covers both standard browsers and Safari
@@ -248,11 +305,14 @@ input.addEventListener('keydown', (e) => {
 ```
 
 > [!NOTE]
+> The `keyCode === 229` requirement only applies when an Enter key check is present. Non-Enter key checks (e.g. `e.key === 'Escape'`) are not subject to this additional requirement, because the Safari event-order issue is specific to Enter confirming IME candidates.
+
+> [!NOTE]
 > `e.keyCode` is deprecated but remains the only reliable way to detect IME composition in Safari's event order. Set `checkKeyCodeForSafari: false` if Safari support is not a concern — `e.isComposing` alone will then be accepted.
 
 ## When Not to Use
 
-If your application intentionally intercepts Enter during IME composition (rare), you can disable this rule inline:
+If your application intentionally intercepts keys during IME composition (rare), you can disable this rule inline:
 
 ```js
 // eslint-disable-next-line ime-safe-form/require-ime-safe-submit

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -212,6 +212,43 @@ const isEnterKeyNode = (node: Node) => isEnterKeyBinaryExpression(node) || isEnt
 export const containsEnterKeyCheck = (node: Node | null | undefined) => walkAst({ predicate: isEnterKeyNode, node });
 
 /**
+ * Check if a BinaryExpression compares any key-related property:
+ *   e.key, e.code, e.keyCode, e.which (any operator, any value)
+ */
+const isKeyCheckBinaryExpression = (node: Node) => {
+  if (node.type !== 'BinaryExpression') {
+    return false;
+  }
+  const { operator, left, right } = node;
+  if (operator !== '===' && operator !== '==' && operator !== '!==' && operator !== '!=') {
+    return false;
+  }
+  const isKeyMember = (candidate: Node) =>
+    ENTER_STRING_PROPS.some((prop) => isMemberWithProp({ node: candidate, propName: prop })) ||
+    LEGACY_CODE_PROPS.some((prop) => isMemberWithProp({ node: candidate, propName: prop }));
+  return isKeyMember(left) || isKeyMember(right);
+};
+
+/**
+ * Check if a SwitchStatement discriminant is a key-related property:
+ *   switch(e.key), switch(e.code), switch(e.keyCode), switch(e.which)
+ */
+const isKeyCheckSwitchStatement = (node: Node) => {
+  if (node.type !== 'SwitchStatement') {
+    return false;
+  }
+  const { discriminant } = node;
+  return (
+    ENTER_STRING_PROPS.some((prop) => isMemberWithProp({ node: discriminant, propName: prop })) ||
+    LEGACY_CODE_PROPS.some((prop) => isMemberWithProp({ node: discriminant, propName: prop }))
+  );
+};
+
+const isKeyCheckNode = (node: Node) => isKeyCheckBinaryExpression(node) || isKeyCheckSwitchStatement(node);
+
+export const containsKeyCheck = (node: Node | null | undefined) => walkAst({ predicate: isKeyCheckNode, node });
+
+/**
  * Check if a BinaryExpression is a keyCode === 229 check (Safari IME guard):
  *   e.keyCode === 229  /  e.keyCode == 229  (and reversed operand order)
  */
@@ -291,30 +328,30 @@ const isPositiveModifierExpression = (node: Node): boolean => {
 
 /**
  * Returns true if the LogicalExpression subtree (connected by &&) has one side
- * containing an Enter key check and the other side being a positive modifier
+ * containing any key check and the other side being a positive modifier
  * expression. Recursively handles chained &&.
  *
  *   e.key === 'Enter' && e.ctrlKey               → true
- *   e.ctrlKey && e.key === 'Enter'               → true
+ *   e.ctrlKey && e.key === 'Tab'                 → true
  *   e.key === 'Enter' && (e.ctrlKey || e.metaKey) → true
  *   e.key === 'Enter' && !e.shiftKey              → false (!modifier ≠ IME guard)
  */
-const andChainHasEnterWithModifier = (node: Node): boolean => {
+const andChainHasKeyWithModifier = (node: Node): boolean => {
   if (node.type !== 'LogicalExpression' || node.operator !== '&&') {
     return false;
   }
   const { left, right } = node;
-  const leftHasEnter = walkAst({ predicate: isEnterKeyNode, node: left });
-  const rightHasEnter = walkAst({ predicate: isEnterKeyNode, node: right });
+  const leftHasKey = containsKeyCheck(left);
+  const rightHasKey = containsKeyCheck(right);
 
-  if (leftHasEnter && isPositiveModifierExpression(right)) {
+  if (leftHasKey && isPositiveModifierExpression(right)) {
     return true;
   }
-  if (rightHasEnter && isPositiveModifierExpression(left)) {
+  if (rightHasKey && isPositiveModifierExpression(left)) {
     return true;
   }
 
-  return andChainHasEnterWithModifier(left) || andChainHasEnterWithModifier(right);
+  return andChainHasKeyWithModifier(left) || andChainHasKeyWithModifier(right);
 };
 
 /**
@@ -340,11 +377,11 @@ export const hasModifierKeyGuard = (node: Node | null | undefined) =>
 
       const { test, consequent } = candidateNode;
 
-      if (andChainHasEnterWithModifier(test)) {
+      if (andChainHasKeyWithModifier(test)) {
         return true;
       }
 
-      return isPositiveModifierExpression(test) && containsEnterKeyCheck(consequent);
+      return isPositiveModifierExpression(test) && containsKeyCheck(consequent);
     },
     node,
   });

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -2,6 +2,7 @@ import type { Rule } from 'eslint';
 import type { BaseNode, Node } from 'estree';
 import {
   containsEnterKeyCheck,
+  containsKeyCheck,
   DEPRECATED_JSX_KEY_EVENTS,
   DEPRECATED_KEY_EVENTS,
   hasGuardFunctionCall,
@@ -17,7 +18,7 @@ import type { JSXAttribute } from './helpers';
 
 const messages = {
   requireImeSafeSubmit:
-    "Enter key detected in '{{eventName}}' without an IME composition guard. Add 'if (e.isComposing) return;' before the check, or handle submission via the form's 'submit' event.",
+    "Key check detected in '{{eventName}}' without an IME composition guard. Add 'if (e.isComposing) return;' before the check, or handle submission via the form's 'submit' event.",
   keypressProhibited:
     "'keypress' is deprecated. Use 'keydown' with an e.isComposing guard instead, or handle submission via the form's 'submit' event.",
   requireKeyCode229:
@@ -124,7 +125,7 @@ const rule: Rule.RuleModule = {
         return;
       }
 
-      if (containsEnterKeyCheck(body)) {
+      if (containsKeyCheck(body)) {
         context.report({
           node: reportNode,
           messageId: allowIsComposingGuard ? 'requireImeSafeSubmit' : 'keypressProhibited',

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -11,16 +11,16 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `form.addEventListener('submit', (e) => { e.preventDefault(); send(); });`,
     },
-    // ── keydown / keyup without Enter check — not a submit pattern ───────────
+    // ── keydown / keyup with isComposing guard — non-Enter key ───────────────
     {
-      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });`,
+      code: `input.addEventListener('keydown', (e) => { if (e.isComposing || e.keyCode === 229) return; if (e.key === 'Escape') close(); });`,
     },
     {
-      code: `input.addEventListener('keyup', (e) => { if (e.key === 'Escape') close(); });`,
+      code: `input.addEventListener('keyup', (e) => { if (e.isComposing || e.keyCode === 229) return; if (e.key === 'Tab') focusNext(); });`,
     },
-    // switch on key without Enter case
+    // switch on non-Enter key with isComposing guard
     {
-      code: `input.addEventListener('keydown', (e) => { switch(e.key) { case 'Escape': close(); break; } });`,
+      code: `input.addEventListener('keydown', (e) => { if (e.isComposing || e.keyCode === 229) return; switch(e.key) { case 'Escape': close(); break; } });`,
     },
     // click event — unrelated
     {
@@ -100,13 +100,9 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `input.addEventListener('keydown', ({ key }) => { if (key === 'Enter') submit(); });`,
     },
-    // ── window.onkeydown — no Enter check ────────────────────────────────────
+    // ── window.onkeydown — with isComposing guard ─────────────────────────────
     {
-      code: `window.onkeydown = (e) => { if (e.key === 'Escape') close(); };`,
-    },
-    // ── keypress without Enter check ─────────────────────────────────────────
-    {
-      code: `input.addEventListener('keypress', (e) => { if (e.key === 'Escape') close(); });`,
+      code: `window.onkeydown = (e) => { if (e.isComposing || e.keyCode === 229) return; if (e.key === 'Escape') close(); };`,
     },
     // ── isComposing guard with switch statement ───────────────────────────────
     {
@@ -132,18 +128,10 @@ tester.run('require-ime-safe-submit', rule, {
       code: `<input onKeyUp={(e) => { if (e.isComposing) return; if (e.key === 'Enter') submitForm(); }} />;`,
       options: [{ checkKeyCodeForSafari: false }],
     },
-    // ── onkeypress assignment without Enter check ────────────────────────────
-    {
-      code: `input.onkeypress = (e) => { if (e.key === 'Escape') close(); };`,
-    },
     // ── isComposing guard with switch statement (keyup) ───────────────────────
     {
       code: `input.addEventListener('keyup', (e) => { if (e.isComposing) return; switch(e.key) { case 'Enter': submit(); break; } });`,
       options: [{ checkKeyCodeForSafari: false }],
-    },
-    // ── JSX onKeyPress without Enter check ───────────────────────────────────
-    {
-      code: `<input onKeyPress={(e) => { if (e.key === 'Escape') close(); }} />;`,
     },
     // ── !== / != early-return pattern with isComposing guard ─────────────────
     {
@@ -327,6 +315,35 @@ tester.run('require-ime-safe-submit', rule, {
   ],
 
   invalid: [
+    // ── non-Enter key checks — same IME race condition ────────────────────────
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keydown' } }],
+    },
+    {
+      code: `input.addEventListener('keyup', (e) => { if (e.key === 'Tab') focusNext(); });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keyup' } }],
+    },
+    {
+      code: `input.addEventListener('keydown', (e) => { switch(e.key) { case 'Escape': close(); break; } });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keydown' } }],
+    },
+    {
+      code: `window.onkeydown = (e) => { if (e.key === 'Escape') close(); };`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onkeydown' } }],
+    },
+    {
+      code: `input.addEventListener('keypress', (e) => { if (e.key === 'Escape') close(); });`,
+      errors: [{ messageId: 'keypressProhibited', data: { eventName: 'keypress' } }],
+    },
+    {
+      code: `input.onkeypress = (e) => { if (e.key === 'Escape') close(); };`,
+      errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onkeypress' } }],
+    },
+    {
+      code: `<input onKeyPress={(e) => { if (e.key === 'Escape') close(); }} />;`,
+      errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onKeyPress' } }],
+    },
     // ── addEventListener keydown ──────────────────────────────────────────────
     {
       code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter') submit(); });`,


### PR DESCRIPTION
## Summary

- Flag any key property comparison (`e.key`, `e.code`, `e.keyCode`, `e.which`) without an `e.isComposing` guard, not just Enter key checks — the same IME race condition applies to all keys (e.g. Escape cancels IME candidates, ArrowDown navigates them)
- Add `containsKeyCheck` helper and generalize `andChainHasEnterWithModifier` → `andChainHasKeyWithModifier`; Safari `keyCode === 229` check remains Enter-specific
- Update `requireImeSafeSubmit` message from "Enter key detected" to "Key check detected"
- Fix missing `allowComponents` option documentation (added in v1.2.0 but never documented)
- Generalize all Enter-specific language in docs; add IME-capable elements table and non-Enter key examples

## Breaking change

Handlers that previously passed (e.g. `if (e.key === 'Escape')` on `<input>` without a guard) will now be flagged. Users need to add `if (e.isComposing || e.keyCode === 229) return;` or move to a non-IME-capable element.

## Test plan

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Non-Enter key cases added to both valid (with guard) and invalid (without guard) sections