### PR TITLE
Fix false positives and improve code clarity (v1.3.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -26,8 +26,8 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: npm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,13 @@ Three handler patterns are detected:
 
 Named function references (e.g. `addEventListener('keydown', handleFn)`) are intentionally not flagged — the handler body cannot be statically analyzed.
 
+### Switch statement detection asymmetry
+
+Two helpers detect `switch` statements, and they differ intentionally:
+
+- **`isEnterKeySwitchStatement`** — checks both the discriminant (`e.key`, `e.keyCode`, etc.) **and** the case values (must be `'Enter'` or `13`). Used by `containsEnterKeyCheck` for the Safari `keyCode === 229` check, which is only relevant when an Enter key is actually handled.
+- **`isKeyCheckSwitchStatement`** — checks the discriminant **only**. Any `switch(e.key)` triggers it regardless of which keys are cased. Used by `containsKeyCheck` because the rule flags *all* key checks in keydown/keyup without an isComposing guard, not just Enter.
+
 ### AST walking
 
 `walkAst()` traverses handler bodies but stops at nested function boundaries (`FUNCTION_TYPES`). This prevents false positives from Enter checks inside `setTimeout` callbacks or similar.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # eslint-plugin-ime-safe-form
 
 [![npm version](https://img.shields.io/npm/v/eslint-plugin-ime-safe-form)](https://www.npmjs.com/package/eslint-plugin-ime-safe-form)
+[![npm downloads](https://img.shields.io/npm/dw/eslint-plugin-ime-safe-form)](https://www.npmjs.com/package/eslint-plugin-ime-safe-form)
+[![CI](https://github.com/hiroya-uga/eslint-plugin-ime-safe-form/actions/workflows/ci.yml/badge.svg)](https://github.com/hiroya-uga/eslint-plugin-ime-safe-form/actions/workflows/ci.yml)
+[![Socket Badge](https://badge.socket.dev/npm/package/eslint-plugin-ime-safe-form)](https://socket.dev/npm/package/eslint-plugin-ime-safe-form)
 [![license](https://img.shields.io/npm/l/eslint-plugin-ime-safe-form)](./LICENSE)
 
 ESLint plugin to enforce IME-safe form submission for users who type with an IME (Input Method Editor).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 1.x     | ✓         |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via
+[GitHub's private vulnerability reporting](https://github.com/hiroya-uga/eslint-plugin-ime-safe-form/security/advisories/new)
+rather than opening a public issue.
+
+Include as much detail as possible: a description of the vulnerability, steps to reproduce, and any potential impact.
+
+You can expect a response within 7 days.

--- a/docs/rules/require-ime-safe-submit.md
+++ b/docs/rules/require-ime-safe-submit.md
@@ -113,6 +113,11 @@ input.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submit();
 });
 
+// ✅ Multiple modifiers with && — requiring both is also safe
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && (e.ctrlKey && e.metaKey)) submit();
+});
+
 // ✅ Outer if with modifier is also recognised
 input.addEventListener('keydown', (e) => {
   if (e.ctrlKey) {
@@ -173,7 +178,7 @@ The JSX patterns (`onKeyDown`, `onKeyUp`, `onKeyPress`) are only checked on elem
 | Element | Flagged |
 |---|---|
 | `<input>`, `<textarea>`, `<select>` | Yes |
-| Any element with `contentEditable` / `contenteditable` (not `"false"`) | Yes |
+| Any element with `contentEditable` / `contenteditable` (not `"false"` or `{false}`) | Yes |
 | PascalCase components (e.g. `<MyInput>`) | Yes (rendered output unknown) |
 | Other elements (`<div>`, `<button>`, `<span>`, …) | No |
 
@@ -207,6 +212,10 @@ Use the [`allowComponents`](#allowcomponents-default-) option to exempt specific
   ```
 
 - **`addEventListener` and `onkeydown =` do not scope by element type.** The rule cannot determine the element the handler is attached to at static analysis time. Even if the handler is on a `<div>`, it will be flagged. Only JSX patterns benefit from element-type scoping.
+
+- **`<Namespace.Component>` syntax is always treated as IME-capable.** Member-expression component names (e.g. `<UI.Input>`) are always flagged. The `allowComponents` option only accepts simple identifiers (e.g. `'Input'`), so there is no way to exempt `<UI.Input>` without using `// eslint-disable`.
+
+- **`guardFunctions` trusts the listed functions blindly, including for the Safari `keyCode === 229` requirement.** The rule cannot inspect the body of the guard function. Any function in `guardFunctions` suppresses `requireKeyCode229` as well as `requireImeSafeSubmit`. Make sure the guard function handles both `e.isComposing` and `e.keyCode === 229` if Safari support is needed.
 
 ## Options
 
@@ -308,7 +317,7 @@ input.addEventListener('keydown', (e) => {
 > The `keyCode === 229` requirement only applies when an Enter key check is present. Non-Enter key checks (e.g. `e.key === 'Escape'`) are not subject to this additional requirement, because the Safari event-order issue is specific to Enter confirming IME candidates.
 
 > [!NOTE]
-> `e.keyCode` is deprecated but remains the only reliable way to detect IME composition in Safari's event order. Set `checkKeyCodeForSafari: false` if Safari support is not a concern — `e.isComposing` alone will then be accepted.
+> `e.keyCode` is deprecated but remains the only reliable way to detect IME composition in Safari's event order up to and including Safari 16 (WebKit). Versions from Safari 16.4 onward have partially fixed this, but the behaviour is inconsistent across platforms. Set `checkKeyCodeForSafari: false` if Safari support is not a concern — `e.isComposing` alone will then be accepted.
 
 ## When Not to Use
 

--- a/docs/rules/require-ime-safe-submit.md
+++ b/docs/rules/require-ime-safe-submit.md
@@ -181,7 +181,7 @@ The JSX patterns (`onKeyDown`, `onKeyUp`, `onKeyPress`) are only checked on elem
 | Element | Flagged |
 |---|---|
 | `<input>`, `<textarea>` | Yes |
-| Any element with `contentEditable` / `contenteditable` (not `"false"` or `{false}`) | Yes |
+| Any element with `contentEditable` / `contenteditable` (not `"false"`, `{false}`, or `{'false'}`) | Yes |
 | PascalCase components (e.g. `<MyInput>`) | Yes (rendered output unknown) |
 | `<select>` | No (uses a dropdown picker; IME text input does not apply) |
 | Other elements (`<div>`, `<button>`, `<span>`, …) | No |

--- a/docs/rules/require-ime-safe-submit.md
+++ b/docs/rules/require-ime-safe-submit.md
@@ -108,7 +108,7 @@ input.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && e.ctrlKey) submit();
 });
 
-// ✅ Multiple modifiers with || are also recognised
+// ✅ Multiple modifiers with || are also recognized
 input.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submit();
 });
@@ -118,7 +118,7 @@ input.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && (e.ctrlKey && e.metaKey)) submit();
 });
 
-// ✅ Outer if with modifier is also recognised
+// ✅ Outer if with modifier is also recognized
 input.addEventListener('keydown', (e) => {
   if (e.ctrlKey) {
     if (e.key === 'Enter') submit();
@@ -147,6 +147,9 @@ input.addEventListener('keydown', (e) => {
 ```jsx
 // ✅ JSX — isComposing + keyCode 229 guard
 <input onKeyDown={(e) => { if (e.isComposing || e.keyCode === 229) return; if (e.key === 'Enter') submitForm(); }} />
+
+// ✅ React synthetic event — e.nativeEvent.isComposing works identically
+<input onKeyDown={(e) => { if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return; if (e.nativeEvent.key === 'Enter') submitForm(); }} />
 
 // ✅ JSX — onSubmit is correct
 <form onSubmit={(e) => { e.preventDefault(); submitForm(); }}>
@@ -177,9 +180,10 @@ The JSX patterns (`onKeyDown`, `onKeyUp`, `onKeyPress`) are only checked on elem
 
 | Element | Flagged |
 |---|---|
-| `<input>`, `<textarea>`, `<select>` | Yes |
+| `<input>`, `<textarea>` | Yes |
 | Any element with `contentEditable` / `contenteditable` (not `"false"` or `{false}`) | Yes |
 | PascalCase components (e.g. `<MyInput>`) | Yes (rendered output unknown) |
+| `<select>` | No (uses a dropdown picker; IME text input does not apply) |
 | Other elements (`<div>`, `<button>`, `<span>`, …) | No |
 
 Use the [`allowComponents`](#allowcomponents-default-) option to exempt specific PascalCase components you know are not IME-capable.
@@ -189,6 +193,7 @@ Use the [`allowComponents`](#allowcomponents-default-) option to exempt specific
 | Pattern | Reason |
 |---|---|
 | `e.isComposing \|\| e.keyCode === 229` guard in `keydown`/`keyup` | Default — covers both standard browsers and Safari |
+| `e.nativeEvent.isComposing \|\| e.nativeEvent.keyCode === 229` (React synthetic event) | React wraps the native event; `nativeEvent.isComposing` is equivalent to the native property |
 | `e.isComposing` guard alone (with `checkKeyCodeForSafari: false`) | Author opted out of Safari check |
 | Guard function call in `IfStatement` (with `guardFunctions` option) | Function is declared as an equivalent IME guard |
 | Key check combined with a modifier via `&&` (`e.ctrlKey`, `e.metaKey`, `e.shiftKey`, `e.altKey`) | IME cannot be composing while a modifier key is held |
@@ -199,9 +204,9 @@ Use the [`allowComponents`](#allowcomponents-default-) option to exempt specific
 
 ### Known limitations
 
-- **Ternary `isComposing` guard is not recognised.** Only `IfStatement` tests are checked. `e.isComposing ? null : (e.key === 'Enter' && submit())` will be flagged even though it is IME-safe. Use an `if` statement instead.
+- **Ternary `isComposing` guard is not recognized.** Only `IfStatement` tests are checked. `e.isComposing ? null : (e.key === 'Enter' && submit())` will be flagged even though it is IME-safe. Use an `if` statement instead.
 - **`!==`/`!=` patterns in a block body are detected but not in isolation.** If the entire handler never reaches the target code after the key check, the flag may be a false positive. Use `// eslint-disable-next-line` for those rare cases.
-- **`isComposing` guard without early exit is not verified.** The rule recognises any `IfStatement` whose condition references `e.isComposing`, regardless of whether the body actually returns or throws. Code like `if (e.isComposing) console.log("composing")` (no `return`) satisfies the check even though it does not prevent key processing. Always pair the guard with `return` (or equivalent).
+- **`isComposing` guard without early exit is not verified.** The rule recognizes any `IfStatement` whose condition references `e.isComposing`, regardless of whether the body actually returns or throws. Code like `if (e.isComposing) console.log("composing")` (no `return`) satisfies the check even though it does not prevent key processing. Always pair the guard with `return` (or equivalent).
 - **Destructured event parameters are not detected.** If the event object is destructured in the handler signature, the rule cannot see the key check and will not flag it. Write the handler as `(e) => { if (e.key === 'Enter') … }` rather than `({ key }) => { if (key === 'Enter') … }`.
 
   ```js
@@ -247,7 +252,7 @@ input.addEventListener('keydown', (e) => {
 });
 ```
 
-Negated calls (`if (!guardIsComposing(e))`) and calls inside compound conditions (`&&`, `||`) are also recognised.
+Negated calls (`if (!guardIsComposing(e))`) and calls inside compound conditions (`&&`, `||`) are also recognized.
 
 > [!NOTE]
 > The rule cannot inspect the body of the guard function. It trusts that any function listed in `guardFunctions` correctly handles IME state, including the Safari `keyCode === 229` case. The `requireKeyCode229` check is skipped for these handlers.

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -75,6 +75,16 @@ export const isImeCapableJsxElement = ({
       return false;
     }
 
+    if (
+      attr.value !== null &&
+      attr.value.type === 'JSXExpressionContainer' &&
+      attr.value.expression !== null &&
+      attr.value.expression.type === 'Literal' &&
+      attr.value.expression.value === false
+    ) {
+      return false;
+    }
+
     return true;
   });
 };
@@ -324,7 +334,7 @@ const isPositiveModifierExpression = (node: Node): boolean => {
   if (isModifierKeyMemberExpression(node)) {
     return true;
   }
-  if (node.type === 'LogicalExpression' && node.operator === '||') {
+  if (node.type === 'LogicalExpression' && (node.operator === '||' || node.operator === '&&')) {
     return isPositiveModifierExpression(node.left) && isPositiveModifierExpression(node.right);
   }
   return false;

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -33,7 +33,7 @@ export interface JSXAttribute extends BaseNode {
 }
 
 
-export const IME_CAPABLE_ELEMENTS = new Set(['input', 'textarea', 'select']);
+export const IME_CAPABLE_ELEMENTS = new Set(['input', 'textarea']);
 
 const CONTENTEDITABLE_PROPS = new Set(['contenteditable', 'contentEditable']);
 const PASCAL_CASE_PATTERN = /^[A-Z]/;

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -32,7 +32,6 @@ export interface JSXAttribute extends BaseNode {
   parent: JSXOpeningElement;
 }
 
-export const isString = (item: unknown): item is string => typeof item === 'string';
 
 export const IME_CAPABLE_ELEMENTS = new Set(['input', 'textarea', 'select']);
 

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -32,7 +32,6 @@ export interface JSXAttribute extends BaseNode {
   parent: JSXOpeningElement;
 }
 
-
 export const IME_CAPABLE_ELEMENTS = new Set(['input', 'textarea']);
 
 const CONTENTEDITABLE_PROPS = new Set(['contenteditable', 'contentEditable']);

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -85,7 +85,7 @@ const ENTER_STRING_PROPS = ['key', 'code'] as const;
 const LEGACY_CODE_PROPS = ['keyCode', 'which'] as const;
 
 export const KEY_EVENTS = new Set(['keydown', 'keyup', 'keypress']);
-// keypress is deprecated: e.isComposing does not exempt it from the rule.
+/** keypress is deprecated: e.isComposing does not exempt it from the rule. */
 export const DEPRECATED_KEY_EVENTS = new Set(['keypress']);
 export const JSX_KEY_EVENTS = new Set(['onKeyDown', 'onKeyUp', 'onKeyPress']);
 export const DEPRECATED_JSX_KEY_EVENTS = new Set(['onKeyPress']);
@@ -164,13 +164,13 @@ const isEnterKeySwitchStatement = (node: Node) => {
   return false;
 };
 
+const isNonFunctionNode = (value: unknown): value is Node =>
+  value !== null && typeof value === 'object' && 'type' in value && !FUNCTION_TYPES.has((value as Node).type);
+
 /**
  * Returns direct child AST nodes, skipping function boundaries and the
  * `parent` back-reference added by ESLint.
  */
-const isNonFunctionNode = (value: unknown): value is Node =>
-  value !== null && typeof value === 'object' && 'type' in value && !FUNCTION_TYPES.has((value as Node).type);
-
 const getChildNodes = (node: Node) => {
   const result: Node[] = [];
   for (const [key, value] of Object.entries(node)) {

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -340,11 +340,11 @@ const isPositiveModifierExpression = (node: Node): boolean => {
 
 /**
  * Returns true if the LogicalExpression subtree (connected by &&) has one side
- * containing any key check and the other side being a positive modifier
+ * containing an Enter key check and the other side being a positive modifier
  * expression. Recursively handles chained &&.
  *
  *   e.key === 'Enter' && e.ctrlKey               → true
- *   e.ctrlKey && e.key === 'Tab'                 → true
+ *   e.ctrlKey && e.key === 'Tab'                 → false (not Enter)
  *   e.key === 'Enter' && (e.ctrlKey || e.metaKey) → true
  *   e.key === 'Enter' && !e.shiftKey              → false (!modifier ≠ IME guard)
  */
@@ -353,13 +353,13 @@ const andChainHasKeyWithModifier = (node: Node): boolean => {
     return false;
   }
   const { left, right } = node;
-  const leftHasKey = containsKeyCheck(left);
-  const rightHasKey = containsKeyCheck(right);
+  const leftHasEnterKey = containsEnterKeyCheck(left);
+  const rightHasEnterKey = containsEnterKeyCheck(right);
 
-  if (leftHasKey && isPositiveModifierExpression(right)) {
+  if (leftHasEnterKey && isPositiveModifierExpression(right)) {
     return true;
   }
-  if (rightHasKey && isPositiveModifierExpression(left)) {
+  if (rightHasEnterKey && isPositiveModifierExpression(left)) {
     return true;
   }
 
@@ -393,7 +393,7 @@ export const hasModifierKeyGuard = (node: Node | null | undefined) =>
         return true;
       }
 
-      return isPositiveModifierExpression(test) && containsKeyCheck(consequent);
+      return isPositiveModifierExpression(test) && containsEnterKeyCheck(consequent);
     },
     node,
   });

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -37,6 +37,22 @@ export const IME_CAPABLE_ELEMENTS = new Set(['input', 'textarea']);
 const CONTENTEDITABLE_PROPS = new Set(['contenteditable', 'contentEditable']);
 const PASCAL_CASE_PATTERN = /^[A-Z]/;
 
+const isExplicitFalseContentEditableValue = (value: JSXAttribute['value']) => {
+  if (value === null) {
+    return false;
+  }
+
+  if (value.type === 'Literal') {
+    return value.value === 'false';
+  }
+
+  return (
+    value.expression !== null &&
+    value.expression.type === 'Literal' &&
+    (value.expression.value === false || value.expression.value === 'false')
+  );
+};
+
 export const isImeCapableJsxElement = ({
   openingElement,
   allowComponents,
@@ -69,17 +85,7 @@ export const isImeCapableJsxElement = ({
       return false;
     }
 
-    if (attr.value !== null && attr.value.type === 'Literal' && attr.value.value === 'false') {
-      return false;
-    }
-
-    if (
-      attr.value !== null &&
-      attr.value.type === 'JSXExpressionContainer' &&
-      attr.value.expression !== null &&
-      attr.value.expression.type === 'Literal' &&
-      attr.value.expression.value === false
-    ) {
+    if (isExplicitFalseContentEditableValue(attr.value)) {
       return false;
     }
 
@@ -348,54 +354,95 @@ const isPositiveModifierExpression = (node: Node): boolean => {
  *   e.key === 'Enter' && (e.ctrlKey || e.metaKey) → true
  *   e.key === 'Enter' && !e.shiftKey              → false (!modifier ≠ IME guard)
  */
-const andChainHasKeyWithModifier = (node: Node): boolean => {
+const andChainHasKeyWithModifier = ({
+  node,
+  containsRelevantKeyCheck,
+}: {
+  node: Node;
+  containsRelevantKeyCheck: (node: Node | null | undefined) => boolean;
+}): boolean => {
   if (node.type !== 'LogicalExpression' || node.operator !== '&&') {
     return false;
   }
   const { left, right } = node;
-  const leftHasEnterKey = containsEnterKeyCheck(left);
-  const rightHasEnterKey = containsEnterKeyCheck(right);
+  const leftHasRelevantKey = containsRelevantKeyCheck(left);
+  const rightHasRelevantKey = containsRelevantKeyCheck(right);
 
-  if (leftHasEnterKey && isPositiveModifierExpression(right)) {
+  if (leftHasRelevantKey && isPositiveModifierExpression(right)) {
     return true;
   }
-  if (rightHasEnterKey && isPositiveModifierExpression(left)) {
+  if (rightHasRelevantKey && isPositiveModifierExpression(left)) {
     return true;
   }
 
-  return andChainHasKeyWithModifier(left) || andChainHasKeyWithModifier(right);
+  return (
+    andChainHasKeyWithModifier({ node: left, containsRelevantKeyCheck }) ||
+    andChainHasKeyWithModifier({ node: right, containsRelevantKeyCheck })
+  );
 };
 
 /**
- * Returns true if the handler body contains a modifier-key guard that makes
- * IME composition impossible. When a modifier key (Ctrl, Meta, Shift, Alt) is
- * held, the IME cannot be in composition state, so e.isComposing is always
- * false and no guard is needed.
- *
- * Pattern A — Enter + modifier in the same && condition:
- *   if (e.key === 'Enter' && e.ctrlKey) …
- *   if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) …
- *
- * Pattern B — outer if whose test is a positive modifier expression, with an
- * Enter check inside the body:
- *   if (e.ctrlKey) { if (e.key === 'Enter') … }
+ * Returns true if the subtree contains a relevant key check that is NOT fully
+ * guarded by a modifier-key condition. A modifier key (Ctrl, Meta, Shift, Alt)
+ * makes IME composition impossible, so key checks that are reachable only while
+ * a modifier is held are exempt.
  */
-export const hasModifierKeyGuard = (node: Node | null | undefined) =>
-  walkAst({
-    predicate: (candidateNode) => {
-      if (candidateNode.type !== 'IfStatement') {
-        return false;
-      }
+const containsRelevantKeyCheckOutsideModifierGuard = ({
+  node,
+  containsRelevantKeyCheck,
+  matchesRelevantKeyCheckNode,
+  visited = new Set<object>(),
+}: {
+  node: Node | null | undefined;
+  containsRelevantKeyCheck: (node: Node | null | undefined) => boolean;
+  matchesRelevantKeyCheckNode: (node: Node) => boolean;
+  visited?: Set<object>;
+}): boolean => {
+  if (node === null || node === undefined || typeof node !== 'object' || visited.has(node)) {
+    return false;
+  }
+  visited.add(node);
 
-      const { test, consequent } = candidateNode;
+  if (node.type === 'IfStatement') {
+    const consequentIsModifierGuarded =
+      andChainHasKeyWithModifier({ node: node.test, containsRelevantKeyCheck }) ||
+      isPositiveModifierExpression(node.test);
 
-      if (andChainHasKeyWithModifier(test)) {
-        return true;
-      }
+    if (consequentIsModifierGuarded) {
+      return containsRelevantKeyCheckOutsideModifierGuard({
+        node: node.alternate,
+        containsRelevantKeyCheck,
+        matchesRelevantKeyCheckNode,
+        visited,
+      });
+    }
+  }
 
-      return isPositiveModifierExpression(test) && containsEnterKeyCheck(consequent);
-    },
+  return (
+    matchesRelevantKeyCheckNode(node) ||
+    getChildNodes(node).some((child) =>
+      containsRelevantKeyCheckOutsideModifierGuard({
+        node: child,
+        containsRelevantKeyCheck,
+        matchesRelevantKeyCheckNode,
+        visited,
+      }),
+    )
+  );
+};
+
+export const containsEnterKeyCheckOutsideModifierGuard = (node: Node | null | undefined) =>
+  containsRelevantKeyCheckOutsideModifierGuard({
     node,
+    containsRelevantKeyCheck: containsEnterKeyCheck,
+    matchesRelevantKeyCheckNode: isEnterKeyNode,
+  });
+
+export const containsKeyCheckOutsideModifierGuard = (node: Node | null | undefined) =>
+  containsRelevantKeyCheckOutsideModifierGuard({
+    node,
+    containsRelevantKeyCheck: containsKeyCheck,
+    matchesRelevantKeyCheckNode: isKeyCheckNode,
   });
 
 /**

--- a/src/rules/helpers.ts
+++ b/src/rules/helpers.ts
@@ -232,6 +232,10 @@ const isKeyCheckBinaryExpression = (node: Node) => {
 /**
  * Check if a SwitchStatement discriminant is a key-related property:
  *   switch(e.key), switch(e.code), switch(e.keyCode), switch(e.which)
+ *
+ * Unlike isEnterKeySwitchStatement, this intentionally does NOT inspect case
+ * values — any switch on a key property is a key check regardless of which
+ * keys are handled.
  */
 const isKeyCheckSwitchStatement = (node: Node) => {
   if (node.type !== 'SwitchStatement') {

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -99,12 +99,13 @@ const rule: Rule.RuleModule = {
       const body = handlerNode.body;
 
       if (allowIsComposingGuard && hasIsComposingCheck(body)) {
-        if (
+        const needsSafariKeyCodeGuard =
           checkKeyCodeForSafari &&
-          !hasKeyCode229Check(body) &&
+          hasKeyCode229Check(body) === false &&
           containsEnterKeyCheck(body) &&
-          !hasModifierKeyGuard(body)
-        ) {
+          hasModifierKeyGuard(body) === false;
+
+        if (needsSafariKeyCodeGuard) {
           context.report({
             node: reportNode,
             messageId: 'requireKeyCode229',
@@ -113,7 +114,9 @@ const rule: Rule.RuleModule = {
         return;
       }
 
-      if (allowIsComposingGuard && guardFunctions.length > 0 && hasGuardFunctionCall({ node: body, guardFunctions })) {
+      const hasUserDefinedGuard = guardFunctions.length > 0 && hasGuardFunctionCall({ node: body, guardFunctions });
+
+      if (allowIsComposingGuard && hasUserDefinedGuard) {
         return;
       }
 
@@ -134,6 +137,7 @@ const rule: Rule.RuleModule = {
       // Pattern 1: element.addEventListener('keydown' | 'keyup' | 'keypress', handler)
       CallExpression(node) {
         const { callee, arguments: args } = node;
+
         if (
           callee.type !== 'MemberExpression' ||
           callee.property.type !== 'Identifier' ||
@@ -144,6 +148,7 @@ const rule: Rule.RuleModule = {
         }
 
         const eventArg = args[0];
+
         if (eventArg === undefined) {
           return;
         }
@@ -162,12 +167,15 @@ const rule: Rule.RuleModule = {
       // Pattern 2: element.onkeydown / onkeyup / onkeypress = handler
       AssignmentExpression(node) {
         const { left, right } = node;
+
         if (left.type !== 'MemberExpression' || left.computed || left.property.type !== 'Identifier') {
           return;
         }
 
-        const propName = left.property.name.toLowerCase();
-        if (propName !== 'onkeydown' && propName !== 'onkeyup' && propName !== 'onkeypress') {
+        const propName = left.property.name;
+        const isOnKeyEventProp = propName.startsWith('on') && KEY_EVENTS.has(propName.slice(2));
+
+        if (isOnKeyEventProp === false) {
           return;
         }
 
@@ -182,6 +190,7 @@ const rule: Rule.RuleModule = {
       // Pattern 3: JSX onKeyDown / onKeyUp / onKeyPress
       JSXAttribute(rawNode: unknown) {
         const node = rawNode as JSXAttribute;
+
         if (node.name.type !== 'JSXIdentifier' || !JSX_KEY_EVENTS.has(node.name.name)) {
           return;
         }
@@ -191,6 +200,7 @@ const rule: Rule.RuleModule = {
         }
 
         const value = node.value;
+
         if (value?.type !== 'JSXExpressionContainer') {
           return;
         }

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -32,7 +32,7 @@ type RuleOptions = {
 
 // ESLint validates schema before create() is called, so a shape check suffices.
 const isRuleOptions = (value: unknown): value is RuleOptions =>
-  value !== null && value !== undefined && typeof value === 'object';
+  value !== null && typeof value === 'object';
 
 const rule: Rule.RuleModule = {
   meta: {

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -137,13 +137,13 @@ const rule: Rule.RuleModule = {
       // Pattern 1: element.addEventListener('keydown' | 'keyup' | 'keypress', handler)
       CallExpression(node) {
         const { callee, arguments: args } = node;
+        const isAddEventListenerCall =
+          callee.type === 'MemberExpression' &&
+          callee.property.type === 'Identifier' &&
+          callee.property.name === 'addEventListener' &&
+          args.length >= 2;
 
-        if (
-          callee.type !== 'MemberExpression' ||
-          callee.property.type !== 'Identifier' ||
-          callee.property.name !== 'addEventListener' ||
-          args.length < 2
-        ) {
+        if (isAddEventListenerCall === false) {
           return;
         }
 
@@ -191,7 +191,9 @@ const rule: Rule.RuleModule = {
       JSXAttribute(rawNode: unknown) {
         const node = rawNode as JSXAttribute;
 
-        if (node.name.type !== 'JSXIdentifier' || !JSX_KEY_EVENTS.has(node.name.name)) {
+        const isJsxKeyEventProp = node.name.type === 'JSXIdentifier' && JSX_KEY_EVENTS.has(node.name.name);
+
+        if (isJsxKeyEventProp === false) {
           return;
         }
 

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -1,6 +1,8 @@
 import type { Rule } from 'eslint';
 import type { BaseNode, Node } from 'estree';
 import {
+  containsEnterKeyCheckOutsideModifierGuard,
+  containsKeyCheckOutsideModifierGuard,
   containsEnterKeyCheck,
   containsKeyCheck,
   DEPRECATED_JSX_KEY_EVENTS,
@@ -8,7 +10,6 @@ import {
   hasGuardFunctionCall,
   hasIsComposingCheck,
   hasKeyCode229Check,
-  hasModifierKeyGuard,
   isImeCapableJsxElement,
   JSX_KEY_EVENTS,
   KEY_EVENTS,
@@ -102,8 +103,7 @@ const rule: Rule.RuleModule = {
         const needsSafariKeyCodeGuard =
           checkKeyCodeForSafari &&
           hasKeyCode229Check(body) === false &&
-          containsEnterKeyCheck(body) &&
-          hasModifierKeyGuard(body) === false;
+          containsEnterKeyCheckOutsideModifierGuard(body);
 
         if (needsSafariKeyCodeGuard) {
           context.report({
@@ -120,7 +120,7 @@ const rule: Rule.RuleModule = {
         return;
       }
 
-      if (allowIsComposingGuard && hasModifierKeyGuard(body)) {
+      if (allowIsComposingGuard && containsKeyCheckOutsideModifierGuard(body) === false) {
         return;
       }
 

--- a/src/rules/require-ime-safe-submit.ts
+++ b/src/rules/require-ime-safe-submit.ts
@@ -10,7 +10,6 @@ import {
   hasKeyCode229Check,
   hasModifierKeyGuard,
   isImeCapableJsxElement,
-  isString,
   JSX_KEY_EVENTS,
   KEY_EVENTS,
 } from './helpers';
@@ -25,18 +24,15 @@ const messages = {
     "In Safari, compositionend fires before keydown, so e.isComposing is false when Enter confirms IME. Add '|| e.keyCode === 229' to the guard: 'if (e.isComposing || e.keyCode === 229) return;'.",
 } as const;
 
-const resolveStringArrayOption = ({ rawOption, key }: { rawOption: unknown; key: string }): string[] => {
-  if (
-    rawOption !== null &&
-    rawOption !== undefined &&
-    typeof rawOption === 'object' &&
-    key in rawOption &&
-    Array.isArray((rawOption as Record<string, unknown>)[key])
-  ) {
-    return ((rawOption as Record<string, unknown>)[key] as unknown[]).filter(isString);
-  }
-  return [];
+type RuleOptions = {
+  checkKeyCodeForSafari?: boolean;
+  guardFunctions?: string[];
+  allowComponents?: string[];
 };
+
+// ESLint validates schema before create() is called, so a shape check suffices.
+const isRuleOptions = (value: unknown): value is RuleOptions =>
+  value !== null && value !== undefined && typeof value === 'object';
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -70,17 +66,12 @@ const rule: Rule.RuleModule = {
   },
 
   create(context) {
-    const rawOption: unknown = context.options[0];
+    const rawOption = context.options[0];
+    const options: RuleOptions = isRuleOptions(rawOption) ? rawOption : {};
     // Default true: only opt out when explicitly { checkKeyCodeForSafari: false }
-    const checkKeyCodeForSafari = !(
-      rawOption !== null &&
-      rawOption !== undefined &&
-      typeof rawOption === 'object' &&
-      'checkKeyCodeForSafari' in rawOption &&
-      (rawOption as Record<string, unknown>)['checkKeyCodeForSafari'] === false
-    );
-    const guardFunctions = resolveStringArrayOption({ rawOption, key: 'guardFunctions' });
-    const allowComponents = resolveStringArrayOption({ rawOption, key: 'allowComponents' });
+    const checkKeyCodeForSafari = options.checkKeyCodeForSafari !== false;
+    const guardFunctions = options.guardFunctions ?? [];
+    const allowComponents = options.allowComponents ?? [];
 
     /**
      * @param allowIsComposingGuard
@@ -108,7 +99,12 @@ const rule: Rule.RuleModule = {
       const body = handlerNode.body;
 
       if (allowIsComposingGuard && hasIsComposingCheck(body)) {
-        if (checkKeyCodeForSafari && !hasKeyCode229Check(body) && containsEnterKeyCheck(body)) {
+        if (
+          checkKeyCodeForSafari &&
+          !hasKeyCode229Check(body) &&
+          containsEnterKeyCheck(body) &&
+          !hasModifierKeyGuard(body)
+        ) {
           context.report({
             node: reportNode,
             messageId: 'requireKeyCode229',

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -221,6 +221,13 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submit(); });`,
     },
+    // multiple modifiers with && — requiring both is also safe; IME cannot compose
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && (e.ctrlKey && e.metaKey)) submit(); });`,
+    },
+    {
+      code: `<input onKeyDown={(e) => { if (e.key === 'Enter' && (e.ctrlKey && e.metaKey)) submitForm(); }} />;`,
+    },
     // legacy keyCode
     {
       code: `input.addEventListener('keydown', (e) => { if (e.keyCode === 13 && e.ctrlKey) submit(); });`,
@@ -251,6 +258,13 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && e.ctrlKey) submit(); });`,
       options: [{ checkKeyCodeForSafari: false }],
+    },
+    // isComposing guard + modifier-gated Enter — requireKeyCode229 must not fire
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.isComposing) return; if (e.key === 'Enter' && e.ctrlKey) submit(); });`,
+    },
+    {
+      code: `<input onKeyDown={(e) => { if (e.isComposing) return; if (e.key === 'Enter' && e.ctrlKey) submitForm(); }} />;`,
     },
     // ── allowComponents option — named components are not flagged ─────────────
     {
@@ -289,6 +303,13 @@ tester.run('require-ime-safe-submit', rule, {
     },
     {
       code: `<div contenteditable="false" onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
+    // contentEditable={false} boolean expression — also not editable
+    {
+      code: `<div contentEditable={false} onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
+    {
+      code: `<div contenteditable={false} onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
     },
     // ── guardFunctions option ──────────────────────────────────────────────────
     // basic: named guard function exempts keydown Enter check
@@ -650,7 +671,15 @@ tester.run('require-ime-safe-submit', rule, {
       errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onkeypress' } }],
     },
     {
+      code: `input.onkeypress = (e) => { switch(e.code) { case 'Enter': submit(); break; } };`,
+      errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onkeypress' } }],
+    },
+    {
       code: `input.onkeypress = (e) => { switch(e.keyCode) { case 13: submit(); break; } };`,
+      errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onkeypress' } }],
+    },
+    {
+      code: `input.onkeypress = (e) => { switch(e.which) { case 13: submit(); break; } };`,
       errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onkeypress' } }],
     },
     // ── keyup + switch(e.code) ────────────────────────────────────────────────
@@ -706,6 +735,10 @@ tester.run('require-ime-safe-submit', rule, {
       code: `<input onKeyPress={(e) => { switch(e.keyCode) { case 13: submit(); break; } }} />;`,
       errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onKeyPress' } }],
     },
+    {
+      code: `<input onKeyPress={(e) => { switch(e.which) { case 13: submit(); break; } }} />;`,
+      errors: [{ messageId: 'keypressProhibited', data: { eventName: 'onKeyPress' } }],
+    },
     // ── modifier key — patterns that are NOT safe ────────────────────────────
     // || instead of && — Enter without modifier still triggers
     {
@@ -726,6 +759,10 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `input.addEventListener('keydown', (e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); });`,
       errors: [{ messageId: "requireImeSafeSubmit", data: { eventName: "keydown" } }],
+    },
+    {
+      code: `input.addEventListener('keyup', (e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); });`,
+      errors: [{ messageId: "requireImeSafeSubmit", data: { eventName: "keyup" } }],
     },
     // guardFunctions with keypress — keypress is deprecated regardless
     {
@@ -770,6 +807,17 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `<OtherInput onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
       options: [{ allowComponents: ['MyInput'] }],
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
+    },
+    // ── JSXMemberExpression (<Namespace.Component>) — always treated as IME-capable ─
+    // allowComponents has no effect; member-expression names cannot be exempted
+    {
+      code: `<Foo.Bar onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
+    },
+    {
+      code: `<Foo.Bar onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
+      options: [{ allowComponents: ['Bar'] }],
       errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
     },
     // ── JSX FunctionExpression (function keyword, not arrow) ─────────────────

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -784,6 +784,10 @@ tester.run('require-ime-safe-submit', rule, {
       code: `<input onKeyDown={(e) => { if (e.ctrlKey && e.key === 'k') openPalette(); if (e.key === 'Enter') submitForm(); }} />;`,
       errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
     },
+    {
+      code: `input.onkeydown = (e) => { if (e.ctrlKey && e.key === 'k') openPalette(); if (e.key === 'Enter') submit(); };`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onkeydown' } }],
+    },
     // isComposing guard + non-Enter modifier shortcut + bare Enter → requireKeyCode229 must fire
     {
       code: `input.addEventListener('keydown', (e) => { if (e.isComposing) return; if (e.ctrlKey && e.key === 'k') openPalette(); if (e.key === 'Enter') submit(); });`,

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -217,6 +217,10 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `input.addEventListener('keydown', (e) => { if (e.ctrlKey && e.key === 'Enter') submit(); });`,
     },
+    // non-Enter shortcut with modifier is also safe
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.ctrlKey && e.key === 'k') openPalette(); });`,
+    },
     // multiple modifiers with ||
     {
       code: `input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) submit(); });`,
@@ -310,6 +314,13 @@ tester.run('require-ime-safe-submit', rule, {
     },
     {
       code: `<div contenteditable={false} onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
+    // contentEditable={'false'} string expression — also not editable
+    {
+      code: `<div contentEditable={'false'} onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
+    },
+    {
+      code: `<div contenteditable={'false'} onKeyDown={(e) => { if (e.key === 'Enter') someAction(); }} />;`,
     },
     // ── guardFunctions option ──────────────────────────────────────────────────
     // basic: named guard function exempts keydown Enter check
@@ -788,9 +799,22 @@ tester.run('require-ime-safe-submit', rule, {
       code: `input.onkeydown = (e) => { if (e.ctrlKey && e.key === 'k') openPalette(); if (e.key === 'Enter') submit(); };`,
       errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onkeydown' } }],
     },
+    // modifier-gated Enter must not exempt a separate bare key check
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.ctrlKey && e.key === 'Enter') submitAlt(); if (e.key === 'Enter') submit(); });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keydown' } }],
+    },
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.ctrlKey && e.key === 'Enter') submitAlt(); if (e.key === 'Escape') close(); });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keydown' } }],
+    },
     // isComposing guard + non-Enter modifier shortcut + bare Enter → requireKeyCode229 must fire
     {
       code: `input.addEventListener('keydown', (e) => { if (e.isComposing) return; if (e.ctrlKey && e.key === 'k') openPalette(); if (e.key === 'Enter') submit(); });`,
+      errors: [{ messageId: 'requireKeyCode229' }],
+    },
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.isComposing) return; if (e.ctrlKey && e.key === 'Enter') submitAlt(); if (e.key === 'Enter') submit(); });`,
       errors: [{ messageId: 'requireKeyCode229' }],
     },
     // ── guardFunctions — guard not in the list → still flagged ────────────────

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -765,6 +765,30 @@ tester.run('require-ime-safe-submit', rule, {
       code: `input.addEventListener('keypress', (e) => { if (e.key === 'Enter' && e.ctrlKey) submit(); });`,
       errors: [{ messageId: 'keypressProhibited', data: { eventName: 'keypress' } }],
     },
+    // ── modifier on a non-Enter shortcut must not exempt a bare Enter check ────
+    // A non-Enter modifier shortcut co-exists with an unguarded Enter check
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.ctrlKey && e.key === 'k') openPalette(); if (e.key === 'Enter') submit(); });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keydown' } }],
+    },
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.key === 'k' && e.ctrlKey) openPalette(); if (e.key === 'Enter') submit(); });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keydown' } }],
+    },
+    // Pattern B variant: modifier outer-if guards only a non-Enter key, Enter is outside
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.ctrlKey) { if (e.key === 'k') openPalette(); } if (e.key === 'Enter') submit(); });`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'keydown' } }],
+    },
+    {
+      code: `<input onKeyDown={(e) => { if (e.ctrlKey && e.key === 'k') openPalette(); if (e.key === 'Enter') submitForm(); }} />;`,
+      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
+    },
+    // isComposing guard + non-Enter modifier shortcut + bare Enter → requireKeyCode229 must fire
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.isComposing) return; if (e.ctrlKey && e.key === 'k') openPalette(); if (e.key === 'Enter') submit(); });`,
+      errors: [{ messageId: 'requireKeyCode229' }],
+    },
     // ── guardFunctions — guard not in the list → still flagged ────────────────
     {
       code: `input.addEventListener('keydown', (e) => { if (guardIsComposing(e)) return; if (e.key === 'Enter') submit(); });`,

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -40,6 +40,16 @@ tester.run('require-ime-safe-submit', rule, {
     {
       code: `input.onkeydown = (e) => { if (e.isComposing || e.keyCode === 229) return; if (e.key === 'Enter') submit(); };`,
     },
+    // ── e.nativeEvent.isComposing (React synthetic event workaround) ─────────
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return; if (e.nativeEvent.key === 'Enter') submit(); });`,
+    },
+    {
+      code: `<input onKeyDown={(e) => { if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return; if (e.nativeEvent.key === 'Enter') submit(); }} />;`,
+    },
+    {
+      code: `input.onkeydown = (e) => { if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return; if (e.nativeEvent.key === 'Enter') submit(); };`,
+    },
     // ── isComposing guard only (checkKeyCodeForSafari: false) ────────────────
     {
       code: `input.addEventListener('keydown', (e) => { if (e.isComposing) return; if (e.key === 'Enter') submit(); });`,
@@ -51,6 +61,15 @@ tester.run('require-ime-safe-submit', rule, {
     },
     {
       code: `input.onkeydown = (e) => { if (e.isComposing) return; if (e.key === 'Enter') submit(); };`,
+      options: [{ checkKeyCodeForSafari: false }],
+    },
+    // e.nativeEvent.isComposing with checkKeyCodeForSafari: false
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.nativeEvent.isComposing) return; if (e.nativeEvent.key === 'Enter') submit(); });`,
+      options: [{ checkKeyCodeForSafari: false }],
+    },
+    {
+      code: `<input onKeyDown={(e) => { if (e.nativeEvent.isComposing) return; if (e.nativeEvent.key === 'Enter') submit(); }} />;`,
       options: [{ checkKeyCodeForSafari: false }],
     },
     // isComposing guard nested inside the Enter check
@@ -777,6 +796,19 @@ tester.run('require-ime-safe-submit', rule, {
     },
     {
       code: `<input onKeyDown={(e) => { if (e.isComposing) return; if (e.key === 'Enter') submit(); }} />;`,
+      errors: [{ messageId: 'requireKeyCode229' }],
+    },
+    // ── e.nativeEvent.isComposing without keyCode 229 ─────────────────────────
+    {
+      code: `input.addEventListener('keydown', (e) => { if (e.nativeEvent.isComposing) return; if (e.nativeEvent.key === 'Enter') submit(); });`,
+      errors: [{ messageId: 'requireKeyCode229' }],
+    },
+    {
+      code: `input.onkeydown = (e) => { if (e.nativeEvent.isComposing) return; if (e.nativeEvent.key === 'Enter') submit(); };`,
+      errors: [{ messageId: 'requireKeyCode229' }],
+    },
+    {
+      code: `<input onKeyDown={(e) => { if (e.nativeEvent.isComposing) return; if (e.nativeEvent.key === 'Enter') submit(); }} />;`,
       errors: [{ messageId: 'requireKeyCode229' }],
     },
     // isComposing with switch

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -352,6 +352,16 @@ tester.run('require-ime-safe-submit', rule, {
       code: `input.addEventListener('keydown', (e) => { if (guardIsComposing(e) && !e.shiftKey) return; if (e.key === 'Enter') submit(); });`,
       options: [{ guardFunctions: ["guardIsComposing"] }],
     },
+    // ── camelCase DOM assignment (onKeyDown, onKeyUp) — not a valid DOM API ─────
+    // DOM properties are case-sensitive: the valid form is onkeydown (lowercase).
+    // onKeyDown is a React JSX prop, not a DOM property, so assignment via = is
+    // not a recognized pattern and is intentionally not flagged.
+    {
+      code: `input.onKeyDown = (e) => { if (e.key === 'Enter') submit(); };`,
+    },
+    {
+      code: `input.onKeyUp = (e) => { if (e.key === 'Enter') submit(); };`,
+    },
   ],
 
   invalid: [

--- a/tests/require-ime-safe-submit.test.ts
+++ b/tests/require-ime-safe-submit.test.ts
@@ -781,10 +781,6 @@ tester.run('require-ime-safe-submit', rule, {
       code: `<textarea onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
       errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
     },
-    {
-      code: `<select onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,
-      errors: [{ messageId: 'requireImeSafeSubmit', data: { eventName: 'onKeyDown' } }],
-    },
     // contentEditable — makes non-input elements IME-capable
     {
       code: `<div contentEditable onKeyDown={(e) => { if (e.key === 'Enter') submit(); }} />;`,


### PR DESCRIPTION
## Summary

- Fix `contentEditable={false}` (boolean JSX expression) being falsely flagged as IME-capable
- Fix `contentEditable={'false'}` (string expression) also treated as explicitly not editable
- Fix `e.ctrlKey && e.metaKey` (both-modifier `&&` pattern) not being recognised as a safe guard
- Fix `requireKeyCode229` false report when `isComposing` guard and modifier-gated Enter are both present
- Fix `onkeydown =` pattern accepting `xxkeydown`-style property names (add `startsWith('on')` guard)
- Fix `<select>` being falsely flagged as IME-capable in JSX
- Fix modifier guard false negative: a modifier-gated branch (e.g. `Ctrl+Enter` or `Ctrl+K`) no longer exempts separate unsafe key checks in the same handler
- Remove redundant `value !== undefined` check in `isRuleOptions`

## Other changes

- Refactor option parsing: replace ad-hoc `Record<string, unknown>` casts with typed `RuleOptions`
- Extract complex multi-condition expressions into named boolean variables for readability
- Remove unused `isString` export from helpers.ts
- Add `e.nativeEvent.isComposing` test cases
- Add missing `switch(e.code/which)` invalid test cases for `onkeypress` and JSX `onKeyPress`
- Add `<Foo.Bar>` member-expression component test cases (known limitation)
- Document `<Namespace.Component>` limitation, `guardFunctions` Safari caveat, and Safari version scope in rule docs
- Pin GitHub Actions to commit SHAs
- Add SECURITY.md

## Test plan

- [x] `npm test` passes
- [x] `npm run typecheck` passes