### PR TITLE
Release v1.3.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,10 +111,10 @@ Publishing a GitHub Release triggers the workflow: typecheck → test → `npm p
 
 Steps:
 
-1. Merge the release branch into `main`
-2. On `main`, bump the version in `package.json`
-3. Commit and push: `git commit -m "Release vX.Y.Z" && git push`
-4. Create and push a tag: `git tag vX.Y.Z && git push --tags`
+1. Merge the release branch into `main` via pull request (direct push to `main` is blocked by branch protection)
+2. Create a new branch (e.g. `release/vX.Y.Z-version-bump`), bump the version in `package.json`, commit with `git commit -m "Release vX.Y.Z"`, and open a PR into `main`
+3. Merge that PR once CI passes
+4. On the updated `main`, create and push a tag: `git tag vX.Y.Z && git push --tags`
 5. Create a GitHub Release from the tag — Actions publishes to npm automatically
 
 Version conventions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,11 +111,10 @@ Publishing a GitHub Release triggers the workflow: typecheck → test → `npm p
 
 Steps:
 
-1. Merge the release branch into `main` via pull request (direct push to `main` is blocked by branch protection)
-2. Create a new branch (e.g. `release/vX.Y.Z-version-bump`), bump the version in `package.json`, commit with `git commit -m "Release vX.Y.Z"`, and open a PR into `main`
-3. Merge that PR once CI passes
-4. On the updated `main`, create and push a tag: `git tag vX.Y.Z && git push --tags`
-5. Create a GitHub Release from the tag — Actions publishes to npm automatically
+1. On the release branch, bump the version in `package.json` and commit: `git commit -m "Release vX.Y.Z"`
+2. Merge the release branch into `main` via pull request (direct push to `main` is blocked by branch protection)
+3. Once merged, create and push a tag: `git tag vX.Y.Z && git push --tags`
+4. Create a GitHub Release from the tag — Actions publishes to npm automatically
 
 Version conventions:
 - **patch** (x.x.Z) — bug fixes, false positive corrections

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-ime-safe-form",
   "description": "ESLint plugin to enforce IME-safe form submission — requires e.isComposing guard or form submit event instead of Enter key detection in keydown/keyup handlers",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Hiroya Uga",
   "bugs": {
     "url": "https://github.com/hiroya-uga/eslint-plugin-ime-safe-form/issues"


### PR DESCRIPTION
Bump version to 1.3.1 and update release process documentation.

This is a separate PR because the version bump was accidentally omitted from the release branch before merging PR #7. Going forward, the version bump will be included in the release branch itself (documented in CLAUDE.md).